### PR TITLE
Adding EXFOR querying to Reaction()

### DIFF
--- a/curie/__init__.py
+++ b/curie/__init__.py
@@ -53,7 +53,7 @@ from .reaction import Reaction
 
 from .stack import Stack
 
-__version__ = '0.0.30'
+__version__ = '0.0.31'
 __all__ = ['download', 'colormap', 'set_style', 
           'Isotope', 'Element', 'Compound', 
           'Spectrum', 'Calibration', 'DecayChain', 

--- a/curie/library.py
+++ b/curie/library.py
@@ -55,11 +55,14 @@ class Library(object):
 			self.db_name = 'irdff'
 		elif name in ['iaea','iaea-cpr','iaea-monitor','cpr','iaea_cpr','iaea_monitor','medical','iaea-medical','iaea_medical']:
 			self.db_name = 'iaea_medical'
+		elif name in ['exfor']:
+			self.db_name = 'exfor'
 		else:
 			raise ValueError('Library {} not recognized.'.format(name))
 
-		self._con = _get_connection(self.db_name)
-		self.name = {'endf':'ENDF/B-VII.1','tendl':'TENDL-2015','irdff':'IRDFF-II','iaea':'IAEA CP-Reference (2017)'}[self.db_name.split('_')[0]]
+		if self.db_name != 'exfor':
+			self._con = _get_connection(self.db_name)
+		self.name = {'endf':'ENDF/B-VII.1','tendl':'TENDL-2015','irdff':'IRDFF-II','iaea':'IAEA CP-Reference (2017)','exfor':'EXFOR'}[self.db_name.split('_')[0]]
 		self._warn = True
 
 	def __str__(self):

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -129,6 +129,8 @@ class Reaction(object):
 				self.unc_xs = np.zeros(len(self.xs))
 			self._interp = None
 			self._interp_unc = None
+		else:
+			self.library = Library('exfor')
 
 		try:
 			if 'nat' not in self.target:
@@ -464,7 +466,7 @@ class Reaction(object):
 	# ---------------------------------------------------------------
 
 
-	def search_exfor(self, plot_results=False, plot_tendl=False):
+	def search_exfor(self, plot_results=False, plot_tendl=False, show_legend=False,xlim=[None,None], ylim=[0,None]):
 		# print(self.name)
 		# self.exfor_target, self.exfor_rxn, self.exfor_product = self.curie_to_exfor()
 		db = exfor_manager.X4DBManagerDefault()
@@ -677,11 +679,11 @@ class Reaction(object):
 
 
 		if plot_results:
-			self.plot_exfor(plot_Dict,self.plot_tendl,multiple_product_subentries)
+			self.plot_exfor(plot_Dict,self.plot_tendl,multiple_product_subentries,show_legend, xlim=xlim, ylim=ylim)
 		
 
 
-	def plot_exfor(self, plot_Dict, plot_tendl=False, multiple_product_subentries=False):
+	def plot_exfor(self, plot_Dict, plot_tendl=False, multiple_product_subentries=False, show_legend=False, xlim=[None,None], ylim=[0,None]):
 		# plt.plot(tendl_data[:,0], tendl_data[:,1], label='TENDL-2021', color='k')
 		# plt.plot(tendl_data_208[:,0], tendl_data_208[:,1], label='209', color='r')
 
@@ -692,17 +694,7 @@ class Reaction(object):
 				# Need to set up list of marker sizes to iterate over with k
 				# print(k)
 				# Use local variables
-				author_name = plot_Dict[index][0]
-				year = plot_Dict[index][1]
-				plot_data = plot_Dict[index][2]
-				subent = plot_Dict[index][3]
-				energy_unit_scalar = plot_Dict[index][4]
-				xs_unit_scalar = plot_Dict[index][5]
-				energy_col = plot_Dict[index][6]
-				xs_col = plot_Dict[index][7]
-				unc_energy_col = plot_Dict[index][8]
-				unc_xs_col = plot_Dict[index][9]
-				subentry_reaction = plot_Dict[index][10]
+				author_name, year , plot_data , subent , energy_unit_scalar , xs_unit_scalar , energy_col , xs_col , unc_energy_col , unc_xs_col, subentry_reaction = plot_Dict[index]
 
 				# print('subent ', subent)
 				# print('energy_col ', energy_col)
@@ -813,13 +805,14 @@ class Reaction(object):
 				plt.plot(rx.eng, tendl_xs, color="k", label='TENDL')
 
 			print('Plotting '+str(len(plot_Dict))+' datasets found in EXFOR for '+self.exfor_target+'('+self.exfor_reaction.replace('*','X')+')'+self.exfor_product)
-			plt.legend()
+			if show_legend:
+				plt.legend()
 			plt.xlabel('Incident Energy (MeV)')
 			plt.ylabel('Cross Section (mb)')
 			# plt.xlim(right=50)
-			# plt.xlim([0,50])
-			# plt.ylim(top=1000)
-			plt.ylim(bottom=0)
+			plt.xlim(xlim)
+			plt.ylim(ylim)
+			# plt.ylim(bottom=0)
 			plt.title(self.exfor_target.capitalize()+'('+self.exfor_reaction.lower().replace('*','x')+')'+self.exfor_product.capitalize())
 			# plt.show()
 			plt.grid(which='major', axis='both', color='w')

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -782,9 +782,9 @@ class Reaction(object):
 				elif "REL" in str(subentry.reaction):
 					print('REL data found in subentry',subentry.subent,', skipping...')
 					continue
-				elif "DERIV" in str(subentry.reaction):
-					print('DERIV data found in subentry',subentry.subent,', skipping...')
-					continue
+				# elif "DERIV" in str(subentry.reaction):
+				# 	print('DERIV data found in subentry',subentry.subent,', skipping...')
+				# 	continue
 				elif "RAW" in str(subentry.reaction):
 					print('RAW data found in subentry',subentry.subent,', skipping...')
 					continue
@@ -1018,6 +1018,12 @@ class Reaction(object):
 					self.enriched = True
 
 				# print(self.exfor_product)
+				# print(self.target_element)
+
+				nearly_monoisotopic_elements = ['H', 'N', 'LA', 'HE', 'O', 'TA', 'C', 'V']
+				if self.target_element.upper() in nearly_monoisotopic_elements:
+					self.enriched = False
+
 
 				product_tendl=self.exfor_product.split('-')[1]+self.exfor_product.split('-')[0]+'g'
 				# print(product_tendl)
@@ -1078,7 +1084,7 @@ class Reaction(object):
 			# plt.savefig('165Er_XS.png', dpi=400)  
 			plt.show()
 		else:
-			print('No matching datasets found!')
+			print('No matching datasets found for '+self.exfor_target+'('+self.exfor_reaction.replace('*','X')+')'+self.exfor_product)
 
 		print('---------------------------')
 

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -394,13 +394,10 @@ class Reaction(object):
 	
 
 	def curie_to_exfor(self):
+		# Parse curie reaction name components
 		parsed_target = self.name.split('(')[0].strip('g')
 		reaction_code = self.name.split('(')[1].split(')')[0].strip('g')
 		parsed_product = self.name.split('(')[1].split(')')[1].strip('g')
-
-		# print(parsed_target)
-
-		# target = ''
 
 		# convert natural abundance notation to EXFOR
 		if 'nat' in parsed_target:
@@ -463,16 +460,15 @@ class Reaction(object):
 
 
 
+	def query():
+		print('test!')
 
-	# ---------------------------------------------------------------
-
-
-	def search_exfor(self, plot_results=False, plot_tendl=False, show_legend=False,xlim=[None,None], ylim=[0,None], verbose=False):
+	def search_exfor(self, plot_results=False, plot_tendl=False, show_legend=False,xlim=[0,None], ylim=[0,None], verbose=False):
 		# print(self.name)
 		# self.exfor_target, self.exfor_rxn, self.exfor_product = self.curie_to_exfor()
 		db = exfor_manager.X4DBManagerDefault()
 		self.target_element = self.exfor_target.split('-')[0].capitalize()
-		multiple_product_subentries = False
+		self.multiple_product_subentries = False
 		
 
 		# Check for *-products (aka A=9999)
@@ -482,7 +478,7 @@ class Reaction(object):
 			self.exfor_product = self.exfor_product.strip('9999')
 			# Avoid a spaghetti plot...
 			self.plot_tendl = False
-			multiple_product_subentries = True
+			self.multiple_product_subentries = True
 		
 		# Check for *-targets (aka A=9999)
 		# print('TARGET:',target)
@@ -490,7 +486,7 @@ class Reaction(object):
 			self.exfor_target = self.exfor_target.strip('9999')
 			# Avoid a spaghetti plot...
 			self.plot_tendl = False
-			multiple_product_subentries = True
+			self.multiple_product_subentries = True
 		else:
 			# Detect if target material is natural abundance
 			if self.exfor_target.split('-')[1] == 0:
@@ -694,15 +690,18 @@ class Reaction(object):
 
 
 		if plot_results:
-			self.plot_exfor(self.plot_tendl,multiple_product_subentries,show_legend, xlim=xlim, ylim=ylim)
+			self.plot_exfor(self.plot_tendl,show_legend, xlim=xlim, ylim=ylim)
 		
 
 
-	def plot_exfor(self, plot_tendl=False, multiple_product_subentries=False, show_legend=False, xlim=[None,None], ylim=[0,None]):
+	def plot_exfor(self, plot_tendl=False, show_legend=False, xlim=[None,None], ylim=[0,None]):
 		# plt.plot(tendl_data[:,0], tendl_data[:,1], label='TENDL-2021', color='k')
 		# plt.plot(tendl_data_208[:,0], tendl_data_208[:,1], label='209', color='r')
 
 		plot_Dict = self.plot_Dict
+
+		fig, ax = plt.subplots(layout='constrained')
+
 
 		if len(plot_Dict) != 0:
 			# Plot results
@@ -730,7 +729,7 @@ class Reaction(object):
 				# print(str(subentry_reaction[0])+'jjjjjjjjj')
 				# print(str(subentry_reaction).split('(')[2])
 
-				if multiple_product_subentries:
+				if self.multiple_product_subentries:
 					if subentry_reaction[0].residual == None:
 						label_string = author_name+' ('+year+') ['+str(subentry_reaction[0].targ)+'('+self.exfor_reaction.replace('*','X').lower()+')'+str(subentry_reaction[0]).split('Unspecified+')[1].strip(')')+']'
 					else:
@@ -823,8 +822,20 @@ class Reaction(object):
 				plt.plot(rx.eng, tendl_xs, color="k", label='TENDL')
 
 			print('Plotting '+str(len(plot_Dict))+' datasets found in EXFOR for '+self.exfor_target+'('+self.exfor_reaction.replace('*','X')+')'+self.exfor_product)
+			ax = plt.gca()
 			if show_legend:
-				plt.legend()
+				legend = fig.legend(loc='outside right upper')
+				# plt.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+
+
+				# ax.set_aspect(2)
+				# plt.tight_layout()
+				# plt.tight_layout(rect=[0, 0, 0.75, 1])
+				fig_width, fig_height = plt.gcf().get_size_inches()
+				fig.set_figwidth(plt.rcParams['figure.figsize'][0]*(1+(legend.get_window_extent().width/(100*fig_width))))
+				# plt.tight_layout(rect=[0, 0, 0.75, 1])
+
+
 			plt.xlabel('Incident Energy (MeV)')
 			plt.ylabel('Cross Section (mb)')
 			# plt.xlim(right=50)
@@ -835,7 +846,7 @@ class Reaction(object):
 			# plt.show()
 			plt.grid(which='major', axis='both', color='w')
 
-			ax = plt.gca()
+			# ax = plt.gca()
 			ax.set_facecolor('#e5ecf6')
 
 			# # Set up second y-axis for plotting isotopic ratios

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -94,6 +94,7 @@ class Reaction(object):
 		self.name = reaction_name
 		self.exfor_target, self.exfor_reaction, self.exfor_product = self.curie_to_exfor()
 		self.plot_tendl = False
+		self.plot_Dict = {}
 		self.multiple_product_subentries = False
 
 		if library.lower()=='best':
@@ -685,19 +686,23 @@ class Reaction(object):
 										  unc_xs_col,  # 9
 										  subentry.reaction)  # 10
 
+		self.plot_Dict = plot_Dict
+
 		if verbose:
 			print('---------------------------')
 		# print(plot_Dict)
 
 
 		if plot_results:
-			self.plot_exfor(plot_Dict,self.plot_tendl,multiple_product_subentries,show_legend, xlim=xlim, ylim=ylim)
+			self.plot_exfor(self.plot_tendl,multiple_product_subentries,show_legend, xlim=xlim, ylim=ylim)
 		
 
 
-	def plot_exfor(self, plot_Dict, plot_tendl=False, multiple_product_subentries=False, show_legend=False, xlim=[None,None], ylim=[0,None]):
+	def plot_exfor(self, plot_tendl=False, multiple_product_subentries=False, show_legend=False, xlim=[None,None], ylim=[0,None]):
 		# plt.plot(tendl_data[:,0], tendl_data[:,1], label='TENDL-2021', color='k')
 		# plt.plot(tendl_data_208[:,0], tendl_data_208[:,1], label='209', color='r')
+
+		plot_Dict = self.plot_Dict
 
 		if len(plot_Dict) != 0:
 			# Plot results

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d
-from x4i3 import exfor_manager, exfor_entry
+from x4i3 import exfor_manager, exfor_entry, exfor_exceptions
 import re
 import matplotlib.pyplot as plt
 
@@ -587,15 +587,33 @@ class Reaction(object):
 			# print (dir(s))
 
 			for subentry in subentry_list:
-				print(subentry)
-				# print(subentry.getSimplified())
+				# print(subentry)
+				# print(subentry.data)
+				# print(dir(subentry))
+				# print(str(subentry.reaction))
+				# print('SFC' in str(subentry.reaction))
 
-				# Make sure data isn't actually RECOM or TTY
-				if "RECOM" in subentry.getSimplified().reaction[0].quantity:
-					print('RECOM data found, skipping...')
-					continue
-				elif "TTY" in subentry.getSimplified().reaction[0].quantity:
-					print('TTY data found, skipping...')
+				try:
+
+					# Make sure data isn't actually RECOM or TTY
+					if "RECOM" in subentry.getSimplified().reaction[0].quantity:
+						print('RECOM data found, skipping...')
+						continue
+					elif "TTY" in subentry.getSimplified().reaction[0].quantity:
+						print('TTY data found, skipping...')
+						continue
+					elif "SFC" in str(subentry.reaction):
+						print('SFC data found, skipping...')
+						continue
+				except exfor_exceptions.NoValuesGivenError:
+					# print('test')
+					# print(subentry.reaction)
+					# ['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', 
+					# '__getitem__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', 
+					# '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__slotnames__', '__slots__', 
+					# '__str__', '__subclasshook__', '__weakref__', 'append', 'author', 'citation', 'coupled', 'csv', 'data', 'getSimplified', 
+					# 'institute', 'labels', 'legend', 'monitor', 'numcols', 'numrows', 'pubType', 'reaction', 'reference', 'reprHeader', 
+					# 'setData', 'simplified', 'sort', 'strHeader', 'subent', 'title', 'units', 'xmgraceHeader', 'year']
 					continue
 				
 
@@ -699,8 +717,14 @@ class Reaction(object):
 				# print(subentry_reaction[0].getReactionType)
 				# print(type(subentry_reaction[0].parse_results))
 
+				# print(type(subentry_reaction[0]))
+				# print(str(subentry_reaction[0])+'jjjjjjjjj')
+
 				if multiple_product_subentries:
-					label_string = author_name+' ('+year+') ['+str(subentry_reaction[0].targ)+'('+self.exfor_reaction.replace('*','X').lower()+')'+str(subentry_reaction[0].residual)+']'
+					if subentry_reaction[0].residual == None:
+						label_string = author_name+' ('+year+') ['+str(subentry_reaction[0].targ)+'('+self.exfor_reaction.replace('*','X').lower()+')'+str(subentry_reaction[0]).split('Unspecified+')[1].strip(')')+']'
+					else:
+						label_string = author_name+' ('+year+') ['+str(subentry_reaction[0].targ)+'('+self.exfor_reaction.replace('*','X').lower()+')'+str(subentry_reaction[0].residual)+']'
 				else:
 					label_string = author_name+' ('+year+')'
 

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -466,7 +466,7 @@ class Reaction(object):
 	# ---------------------------------------------------------------
 
 
-	def search_exfor(self, plot_results=False, plot_tendl=False, show_legend=False,xlim=[None,None], ylim=[0,None]):
+	def search_exfor(self, plot_results=False, plot_tendl=False, show_legend=False,xlim=[None,None], ylim=[0,None], verbose=False):
 		# print(self.name)
 		# self.exfor_target, self.exfor_rxn, self.exfor_product = self.curie_to_exfor()
 		db = exfor_manager.X4DBManagerDefault()
@@ -552,7 +552,8 @@ class Reaction(object):
 
 			else:
 				# Poorly-formatted EXFOR - multiple subentries for one entry
-				print('Number of datasets found in entry', next(iter(datasets))[1][0:5], ': ', num_of_sub_subentries)
+				if verbose:
+					print('Number of datasets found in entry', next(iter(datasets))[1][0:5], ': ', num_of_sub_subentries)
 				# print('Other datasets in this entry: ',datasets.keys())
 				# print(type(datasets))
 
@@ -674,7 +675,8 @@ class Reaction(object):
 										  unc_xs_col,  # 9
 										  subentry.reaction)  # 10
 
-		print('---------------------------')
+		if verbose:
+			print('---------------------------')
 		# print(plot_Dict)
 
 

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -461,10 +461,12 @@ class Reaction(object):
 
 
 	def search_exfor(self, plot_results=False, plot_tendl=False, show_legend=False,xlim=[0,None], ylim=[0,None], verbose=False):
-		print('test!')
+		# print('test!')
 		# print('TARGET:',self.exfor_target)
 		# print('PRODUCT:',self.exfor_product)
 		# Check for *-targets (aka A=9999)
+		self.multiple_product_subentries = False
+
 		if '9999' in self.exfor_target:
 			# Loop over all stable isotopes of element, along with A=0 (natural abundance)
 			self.exfor_target = self.exfor_target.strip('9999')
@@ -481,10 +483,10 @@ class Reaction(object):
 			isotopes = np.append(isotopes, '0'+self.exfor_target)
 
 			# print(abundances)
-			print(isotopes)
+			# print(isotopes)
 
 			for itp in isotopes:
-				print('* Target Isotope: ',itp)
+				# print('* Target Isotope: ',itp)
 				substrings = re.split('(\D+)',itp)
 				# exfor_target = (substrings[1]+'-'+substrings[0]).strip(' ').upper()
 				self.exfor_target = (substrings[1]+'-'+substrings[0]).upper()
@@ -500,10 +502,10 @@ class Reaction(object):
 		# self.exfor_target, self.exfor_rxn, self.exfor_product = self.curie_to_exfor()
 		db = exfor_manager.X4DBManagerDefault()
 		self.target_element = self.exfor_target.split('-')[0].capitalize()
-		self.multiple_product_subentries = False
+		# self.multiple_product_subentries = False
 
-		print('TARGET:',self.exfor_target)
-		print('PRODUCT:',self.exfor_product)
+		# print('TARGET:',self.exfor_target)
+		# print('PRODUCT:',self.exfor_product)
 		
 
 		# Check for *-products (aka A=9999)
@@ -606,6 +608,7 @@ class Reaction(object):
 			# 	continue
 			if len(subentry_list) == 0:
 				continue
+				
 
 			# print(len(subentry))
 			# print(subentry_list)
@@ -622,9 +625,12 @@ class Reaction(object):
 			# print (dir(s))
 
 			for subentry in subentry_list:
+				xs_col = -1
+				unc_xs_col = -1
 				if  verbose:
 					print(subentry)
 					print(subentry.subent)
+					print(str(subentry.reaction))
 				# print(subentry.data)
 				# print(dir(subentry))
 				# print(str(subentry.reaction))
@@ -643,6 +649,21 @@ class Reaction(object):
 					continue
 				elif "SFC" in str(subentry.reaction):
 					print('SFC data found in subentry',subentry.subent,', skipping...')
+					continue
+				elif "/" in str(subentry.reaction):
+					print('Ratio data found in subentry',subentry.subent,', skipping...')
+					continue
+				elif "PAR" in str(subentry.reaction):
+					print('Partial XS data found in subentry',subentry.subent,', skipping...')
+					continue
+				elif "REL" in str(subentry.reaction):
+					print('REL data found in subentry',subentry.subent,', skipping...')
+					continue
+				elif "DERIV" in str(subentry.reaction):
+					print('DERIV data found in subentry',subentry.subent,', skipping...')
+					continue
+				elif "RAW" in str(subentry.reaction):
+					print('RAW data found in subentry',subentry.subent,', skipping...')
 					continue
 				# except NoValuesGivenError:
 				# 	# print('test')
@@ -698,11 +719,16 @@ class Reaction(object):
 				else:
 					print("No XS units found for entry", next(iter(datasets))[1][0:5])
 
+				if xs_col == -1:
+					print('No XS able to be extracted for entry', next(iter(datasets))[1][0:5])
+					continue
+
 				# print(subentry.getSimplified().data)
 				author_name = subentry.author[0].split('.',-1)[-1]
 				year = subentry.year
 				# print(author_name)
 				# print(year)
+				# print(subentry)
 				# print(subentry.subent)
 				# print(type(subentry))
 				# print(str(subentry.reaction[0].residual))
@@ -710,7 +736,7 @@ class Reaction(object):
 					residual = str(subentry.reaction[0]).split('Unspecified+')[1].strip(')')
 				else:
 					residual = str(subentry.reaction[0].residual)
-				plot_Dict[author_name+year+subentry.subent] = (author_name, # 0
+				plot_Dict[author_name+year+subentry.subent+residual] = (author_name, # 0
 										  year, # 1
 										  np.array(subentry.data, dtype=float),  # 2
 										  subentry.subent, # 3
@@ -731,6 +757,7 @@ class Reaction(object):
 
 
 		if plot_results:
+			# print(plot_Dict)
 			self.plot_exfor(self.plot_tendl,show_legend, xlim=xlim, ylim=ylim)
 		
 
@@ -747,14 +774,14 @@ class Reaction(object):
 		if len(plot_Dict) != 0:
 			# Plot results
 			fig, ax = plt.subplots(layout='constrained')
-			
+
 			k=0
 			for index in plot_Dict:
 				# Need to set up list of marker sizes to iterate over with k
 				# print(k)
 				# Use local variables
 				author_name, year , plot_data , subent , energy_unit_scalar , xs_unit_scalar , energy_col , xs_col , unc_energy_col , unc_xs_col, subentry_reaction, residual = plot_Dict[index]
-
+				# print(plot_Dict[index])
 				# print('subent ', subent)
 				# print('energy_col ', energy_col)
 				# print('xs_col ', xs_col)
@@ -906,6 +933,8 @@ class Reaction(object):
 			plt.show()
 		else:
 			print('No matching datasets found!')
+
+		print('---------------------------')
 
 
 	

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -670,6 +670,11 @@ class Reaction(object):
 				# print(year)
 				# print(subentry.subent)
 				# print(type(subentry))
+				# print(str(subentry.reaction[0].residual))
+				if subentry.reaction[0].residual == None:
+					residual = str(subentry.reaction[0]).split('Unspecified+')[1].strip(')')
+				else:
+					residual = str(subentry.reaction[0].residual)
 				plot_Dict[author_name+year+subentry.subent] = (author_name, # 0
 										  year, # 1
 										  np.array(subentry.data, dtype=float),  # 2
@@ -680,7 +685,8 @@ class Reaction(object):
 										  xs_col, # 7
 										  unc_energy_col, # 8 
 										  unc_xs_col,  # 9
-										  subentry.reaction)  # 10
+										  subentry.reaction,  # 10
+										  residual)  #11
 
 		self.plot_Dict = plot_Dict
 
@@ -710,7 +716,7 @@ class Reaction(object):
 				# Need to set up list of marker sizes to iterate over with k
 				# print(k)
 				# Use local variables
-				author_name, year , plot_data , subent , energy_unit_scalar , xs_unit_scalar , energy_col , xs_col , unc_energy_col , unc_xs_col, subentry_reaction = plot_Dict[index]
+				author_name, year , plot_data , subent , energy_unit_scalar , xs_unit_scalar , energy_col , xs_col , unc_energy_col , unc_xs_col, subentry_reaction, residual = plot_Dict[index]
 
 				# print('subent ', subent)
 				# print('energy_col ', energy_col)
@@ -731,9 +737,9 @@ class Reaction(object):
 
 				if self.multiple_product_subentries:
 					if subentry_reaction[0].residual == None:
-						label_string = author_name+' ('+year+') ['+str(subentry_reaction[0].targ)+'('+self.exfor_reaction.replace('*','X').lower()+')'+str(subentry_reaction[0]).split('Unspecified+')[1].strip(')')+']'
+						label_string = author_name+' ('+year+') ['+str(subentry_reaction[0].targ)+'('+self.exfor_reaction.replace('*','X').lower()+')'+residual+']'
 					else:
-						label_string = author_name+' ('+year+') ['+str(subentry_reaction[0].targ)+'('+str(subentry_reaction).split('(')[2].split(')')[0].replace('*','X').lower()+')'+str(subentry_reaction[0].residual)+']'
+						label_string = author_name+' ('+year+') ['+str(subentry_reaction[0].targ)+'('+str(subentry_reaction).split('(')[2].split(')')[0].replace('*','X').lower()+')'+residual+']'
 				else:
 					label_string = author_name+' ('+year+')'
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='curie',
-	  version='0.0.30',
+	  version='0.0.31',
 	  description='Curie is a python toolkit to aid in the analysis of experimental nuclear data.',
 	  long_description=long_description,
 	  long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -54,4 +54,4 @@ setup(name='curie',
 	  packages=find_packages(),
 	  include_package_data=True,
 	  cmdclass={'install': install})#, 
-	  #install_requires=['numpy', 'matplotlib', 'scipy', 'pandas'])
+	  #install_requires=['numpy', 'matplotlib', 'scipy', 'pandas', 'x4i3'])


### PR DESCRIPTION
This  branch extends the Reaction class to support for querying the EXFOR database in an API-like manner, to retrieve reaction data via the Reaction class.  The core for this is Dave Brown's x4i3 package (https://github.com/afedynitch/x4i3), the new methods in Reaction wrap this package into a far more convenient frontend.

I initially thought about making a new class for this, but it seemed redundant in many ways, so I decided to extend Reaction instead.   This involved a few minor tweaks to Library, to allow it to better recognize EXFOR data instead, particularly when wildcards are used for targets and/or products  If you'd rather this be a standalone class, I'm super open to that also!   Just let me know!  :)


The core of this update is the new Reaction.search_exfor() method:

Front-end method to search for EXFOR data for the reaction (or reactions) defined in  ci.Reaction(). Unlike reaction data retrieved from other Curie data libraries, this search supports the use of natural abundance targets and the use of wildcards for both target,  reaction channel, and product. Additional optional parameters control the plotting and  level of verbose output. This provides an API-like access for EXFOR data, but users may  want to compare against queries through the EXFOR web portal, due to the fact that EXFOR  compilations may be entered inconsistently, particularly for older data sets.

The first time that Reaction.search_exfor() is called, Curie will download the most recent  copy of the EXFOR database. The x4i3-tools Python package provides tools to manually update  your local EXFOR database, but native upgrade support will be added in future updates.

Currently, supported targets include individual isotopes (as in the rest of Curie) (e.g.,  '226RA'), natural abundance targets (e.g., '0FE', '0PB'), and wildcards (e.g., '*LA', '*V'),  which which includes both A=0 for the specified element, as well as all of its stable  isotopes. The target element must still be specified, but support for wildcard elements (e.g.,  '*(p,x)56CO') will be added in future updates. 

Similarly, reaction channels may be specified as normal in Curie (e.g., '(p,x)', '(p,2n)',  'd,a4n'), or using wildcards for exit channels (e.g., '(p,x)', '(p,*)', where 'x' and '*'  serve interchangeably), though the incident particle must still be specified.

Currently, supported products include individual isotopes (as in the rest of Curie) (e.g.,  '225RA'), and wildcards (e.g., '*CO', '*CE', '*TL'), which will retrieve results for all   isotopes of the specified product (or wildcard target). This also includes wildcard elements  (e.g., '56FE(p,x)*'). When plotting results for a wildcard product, the plot legend will provide   extra metadata to specify the reaction channel for each dataset.

Combinations of any of the above supported wildcards may be used together and interchangeably,  offering data retrieval power comparable to the EXFOR web portal, but with greater ease for programmatic use.


I've attached a quick script with the range of examples I used as test cases to make sure this is working as I believe I intended - play around, and try other cases too!  It seems to work well for (p,x), (d,x), (a,x) and (n,x) data so far.  However, given how wide the variation in how each EXFOR entry is formatted for data (especially older ones...), there are likely many cases we'll find that need some tweaks in the future.


There are a few outstanding tasks I'll add in in the future:

1. Currently, the retrieved data is stored in a dictionary for plotting.  I want to change this to a pandas df to make sorting and grouping more possible for plotting.
2. After the initial install of x4i3, a separate package (x4i3-tools) is needed to update your local database.  I want to add an extension to Curie.Data to add the same functionality 
3. Eventually, moving to using a SQL database for the EXFOR master file would be more convenient, rather than relying upon the processed master file that I get from Otsuka-san at present.  if so, I'll update this to use that as the library instead.
[plot_exfor_test.txt](https://github.com/jtmorrell/curie/files/14471870/plot_exfor_test.txt)
