### PR TITLE
Hotfix release 0.0.35: crash fixes, clear errors, data-v1 downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ curie_improvement_plan.md
 
 # Local Claude Code working notes (do not commit upstream)
 CLAUDE.md
+.claude/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,63 @@
 Notable changes to curie are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.0.35] - 2026-07-01
+
+Crash-fix (hotfix) release. Two fixes change numerical results; they are called
+out below. All other numbers are unchanged from 0.0.34.
+
+### Fixed
+- `Spectrum(..., cb=...)` crashed for `Calibration` objects (mis-parenthesized
+  type check).
+- `Spectrum.saveas('*.Chn')` crashed for any spectrum with a real sample
+  description; description and calibration fields are now padded to the fixed
+  widths the reader expects.
+- `DecayChain.activity()`/`decays()` raised `KeyError` for stable chain
+  members; they now return 0.
+- Exactly equal decay constants in a chain produced inf/nan activities
+  (`sign(0)=0` defeated the degeneracy guard).
+- `Isotope.dose_rate(units='Sv/...')` raised `KeyError`, and the sievert
+  weighting was discarded even when it evaluated; alpha dose is now weighted
+  by w_R=20.
+- `DecayChain.get_counts` raised `NameError` (Python 2 `unicode` reference)
+  for non-string start times.
+- The `Compound` `.db` round-trip was broken end-to-end (writer and readers
+  disagreed on the table name; the compound name was interpolated unquoted).
+- A failed `ci.download()` could truncate an existing database to zero bytes,
+  and the zero-byte residue was then treated as installed. Downloads now write
+  to a temporary file with an atomic rename.
+- A missing *proton* reaction with `library='best'` died with a bare
+  `IndexError` instead of a clear `ValueError`.
+- `DecayChain('238U')` crashed on database records with no atomic mass (71
+  exotic nuclides reached through spontaneous-fission daughters); the mass is
+  now reconstructed from the mass excess. A missing half-life is treated as
+  stable with a visible warning.
+- A failed peak fit is now reported with a WARNING naming the isotopes and
+  energies instead of being dropped silently, and `fit_peaks` no longer
+  crashes when every fit fails.
+- Clear error messages for: isotope names absent from the decay database
+  (e.g. `Isotope('natFe')` — use `Element`), elements beyond Z=92 (no
+  stopping-power/attenuation data), and stack foils whose areal density
+  cannot be determined.
+- Deprecated `fillna(method='ffill')` calls (pandas 3.x compatibility).
+- Four broken documentation examples.
+
+### Changed — numerical results
+- **`Compound.range()`** now integrates from 1 keV instead of 1 MeV, matching
+  `Element.range()`. Low-energy ranges change by up to ~36% (at 2 MeV);
+  the change at 60 MeV is ~0.1%. The old values were wrong.
+- **`Library.retrieve`** (and therefore `Reaction`) now sorts energy grids on
+  load and drops exact duplicate rows. Several `iaea_monitors` reactions
+  (e.g. natFe(p,x)51Cr, 98Mo(n,g)99Mo) store points out of order, which
+  corrupted `integrate`/`average`. Results for those reactions change; the
+  old values were wrong.
+
+### Changed — packaging
+- All nuclear-data downloads (`ci.download()` and the install hook) now fetch
+  from the immutable `data-v1` GitHub release (SHA256s in
+  `data_manifest.toml`) instead of Dropbox.
+- `setup.py` now declares `install_requires` (numpy, scipy, pandas,
+  matplotlib) and `python_requires>=3.9`.
 
 ## [0.0.34] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+Notable changes to curie are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [0.0.34] - 2026-06-08
+
+### Changed
+- `Reaction.average` and `Reaction.integrate` now use bin-center midpoint
+  quadrature instead of trapezoidal integration, removing a foil-thickness
+  dependence in flux-averaged cross sections when the flux spectrum contains
+  endpoint spikes (e.g. post-stop residence pile-up from over-stopping foils
+  in `Stack`). Docstring example values shift by ~1%.
+
+### Added
+- Public test suite (`tests/`, run with `python -m pytest`) and a CI workflow
+  covering Python 3.9-3.13.
+- `data_manifest.toml`: size and SHA256 records for the shipped nuclear-data
+  databases, matching the `data-v1` release assets.
+
+## Earlier releases
+
+Releases up to 0.0.33 predate this changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,19 @@ out below. All other numbers are unchanged from 0.0.34.
   type check).
 - `Spectrum.saveas('*.Chn')` crashed for any spectrum with a real sample
   description; description and calibration fields are now padded to the fixed
-  widths the reader expects.
+  widths the reader expects, and zero-length descriptions no longer corrupt
+  the record layout.
+- Reading a `.Chn` file with 8192 or more channels truncated the histogram to
+  zero length under numpy 2 (16-bit integer overflow in the reader).
+- `235U(n,g)` and `235U(n,2n)` from the TENDL library crashed on interpolation
+  (a duplicated energy point in the stored grid); duplicate energies are now
+  dropped for the spline-interpolated TENDL libraries.
 - `DecayChain.activity()`/`decays()` raised `KeyError` for stable chain
   members; they now return 0.
 - Exactly equal decay constants in a chain produced inf/nan activities
-  (`sign(0)=0` defeated the degeneracy guard).
+  (`sign(0)=0` defeated the degeneracy guard). The tied pair's terms now
+  cancel, matching the guard's behavior for nearly-equal constants (an exact
+  confluent-eigenvalue solution is planned as a result-changing fix).
 - `Isotope.dose_rate(units='Sv/...')` raised `KeyError`, and the sievert
   weighting was discarded even when it evaluated; alpha dose is now weighted
   by w_R=20.
@@ -42,17 +50,32 @@ out below. All other numbers are unchanged from 0.0.34.
   stopping-power/attenuation data), and stack foils whose areal density
   cannot be determined.
 - Deprecated `fillna(method='ffill')` calls (pandas 3.x compatibility).
-- Four broken documentation examples.
+- Broken or stale documentation examples (`Reaction.interpolate`/`integrate`,
+  `DecayChain`, `Element.range`, `Compound.range`, `Isotope.dose_rate`, and
+  the decay example script's removed `N_plot` keyword).
 
 ### Changed — numerical results
 - **`Compound.range()`** now integrates from 1 keV instead of 1 MeV, matching
-  `Element.range()`. Low-energy ranges change by up to ~36% (at 2 MeV);
-  the change at 60 MeV is ~0.1%. The old values were wrong.
+  `Element.range()`. The old value at 2 MeV was ~36% low, with the discrepancy
+  growing rapidly below that (old values below ~1 MeV were essentially
+  meaningless); at 60 MeV the change is ~0.1%. The old values were wrong.
 - **`Library.retrieve`** (and therefore `Reaction`) now sorts energy grids on
   load and drops exact duplicate rows. Several `iaea_monitors` reactions
   (e.g. natFe(p,x)51Cr, 98Mo(n,g)99Mo) store points out of order, which
   corrupted `integrate`/`average`. Results for those reactions change; the
   old values were wrong.
+- **IAEA reactions with both a direct and a cumulative excitation function**
+  for the same target and product (124Xe(p,pn)/(p,x)123Xe and
+  176Yb(d,n)/(d,x)177Lu) previously returned the union of the two curves;
+  each channel now returns its own data.
+
+### Known data defects (deferred to the data-library rebuild)
+- Three `iaea_monitors` tables carry defective rows that survive sorting:
+  15N(p,n)15O and 98Mo(n,g)99Mo contain two conflicting copies of parts of
+  their evaluations, and natFe(p,x)51Cr has one spurious point
+  (4230 mb at 157 MeV) that distorts interpolation between 157.0 and
+  157.1 MeV. These are stored-data defects and will be corrected in the
+  rebuilt data libraries.
 
 ### Changed — packaging
 - All nuclear-data downloads (`ci.download()` and the install hook) now fetch
@@ -61,7 +84,13 @@ out below. All other numbers are unchanged from 0.0.34.
 - `setup.py` now declares `install_requires` (numpy, scipy, pandas,
   matplotlib) and `python_requires>=3.9`.
 
-## [0.0.34] - 2026-06-08
+### Added
+- Public test suite (`tests/`, run with `python -m pytest`) and a CI workflow
+  covering Python 3.9-3.13.
+- `data_manifest.toml`: size and SHA256 records for the shipped nuclear-data
+  databases, matching the `data-v1` release assets.
+
+## [0.0.34] - 2026-05-06
 
 ### Changed
 - `Reaction.average` and `Reaction.integrate` now use bin-center midpoint
@@ -69,12 +98,6 @@ out below. All other numbers are unchanged from 0.0.34.
   dependence in flux-averaged cross sections when the flux spectrum contains
   endpoint spikes (e.g. post-stop residence pile-up from over-stopping foils
   in `Stack`). Docstring example values shift by ~1%.
-
-### Added
-- Public test suite (`tests/`, run with `python -m pytest`) and a CI workflow
-  covering Python 3.9-3.13.
-- `data_manifest.toml`: size and SHA256 records for the shipped nuclear-data
-  databases, matching the `data-v1` release assets.
 
 ## Earlier releases
 

--- a/curie/__init__.py
+++ b/curie/__init__.py
@@ -53,7 +53,7 @@ from .reaction import Reaction
 
 from .stack import Stack
 
-__version__ = '0.0.34'
+__version__ = '0.0.35'
 __all__ = ['download', 'colormap', 'set_style', 
           'Isotope', 'Element', 'Compound', 
           'Spectrum', 'Calibration', 'DecayChain', 

--- a/curie/calibration.py
+++ b/curie/calibration.py
@@ -509,7 +509,7 @@ class Calibration(object):
 			if sources.endswith('.json'):
 				sources = pd.DataFrame(json.loads(open(sources).read()))
 			elif sources.endswith('.csv'):
-				sources = pd.read_csv(sources, header=0).fillna(method='ffill')
+				sources = pd.read_csv(sources, header=0).ffill()
 			elif sources.endswith('.db'):
 				sources = pd.read_sql('SELECT * FROM sources', _get_connection(sources))
 		else:

--- a/curie/compound.py
+++ b/curie/compound.py
@@ -471,17 +471,17 @@ class Compound(object):
 		--------
 		>>> cm = ci.Compound('Fe') # same behavior as element
 		>>> print(cm.range(60.0))
-		0.5858151125192633
+		0.5866312594085556
 		>>> cm = ci.Compound('SS_316') # preset compound
 		>>> print(cm.range(60.0))
-		0.5799450918147814
+		0.5807353363913145
 
 		"""
 
 		energy = np.asarray(energy, dtype=np.float64)
 		
 		dE = np.max(energy)/1E3
-		E_min = min((np.min(energy), 1.0))
+		E_min = min((np.min(energy), 1E-3))
 		E_grid = np.arange(E_min, np.max(energy)+dE, dE)
 
 		S = self.S(E_grid, particle=particle, density=density)

--- a/curie/compound.py
+++ b/curie/compound.py
@@ -161,7 +161,7 @@ class Compound(object):
 						weights = weights[weights['compound']==self.name]
 
 				elif weights.endswith('.db'):
-					weights = pd.read_sql('SELECT * FROM compounds WHERE compound={}'.format(self.name), _get_connection(weights))
+					weights = pd.read_sql('SELECT * FROM compounds WHERE compound=?', _get_connection(weights), params=(self.name,))
 					weights.columns = map(str.lower, map(str, weights.columns))
 					if 'compound' in weights.columns:
 						weights = weights[weights['compound']==self.name]
@@ -275,12 +275,12 @@ class Compound(object):
 		if filename.endswith('.db'):
 			if os.path.exists(filename) and not replace:
 				con = _get_connection(filename)
-				df = pd.read_sql('SELECT * FROM weights', con)
+				df = pd.read_sql('SELECT * FROM compounds', con)
 				df = df[df['compound']!=self.name]
 				df = pd.concat([df, wts])
-				df.to_sql('weights', con, if_exists='replace', index=False)
+				df.to_sql('compounds', con, if_exists='replace', index=False)
 			else:
-				wts.to_sql('weights', _get_connection(filename), if_exists='replace', index=False)
+				wts.to_sql('compounds', _get_connection(filename), if_exists='replace', index=False)
 
 		if filename.endswith('.json'):
 			if os.path.exists(filename) and not replace:

--- a/curie/compound.py
+++ b/curie/compound.py
@@ -149,13 +149,13 @@ class Compound(object):
 
 			elif type(weights)==str:
 				if weights.endswith('.json'):
-					weights = pd.read_json(weights, orient='records').fillna(method='ffill')
+					weights = pd.read_json(weights, orient='records').ffill()
 					weights.columns = map(str.lower, map(str, weights.columns))
 					if 'compound' in weights.columns:
 						weights = weights[weights['compound']==self.name]
 
 				elif weights.endswith('.csv'):
-					weights = pd.read_csv(weights, header=0).fillna(method='ffill')
+					weights = pd.read_csv(weights, header=0).ffill()
 					weights.columns = map(str.lower, map(str, weights.columns))
 					if 'compound' in weights.columns:
 						weights = weights[weights['compound']==self.name]

--- a/curie/data.py
+++ b/curie/data.py
@@ -69,9 +69,6 @@ def download(db='all', overwrite=False):
 		print('db={} not recognized.'.format(db))
 		return
 
-	addr = {'decay':'wwd6b1gk2ge5tgt', 'endf':'tkndjqs036piojm', 'tendl':'zkoi6t2jicc9yqs', 'tendl_d_rp':'x2vfjr7uv7ffex5', 'tendl_n_rp':'n0jjc0dv61j9of9',
-				'tendl_p_rp':'ib2a5lrhiwkcro5', 'ziegler':'kq07684wtp890v5', 'iaea_monitors':'lzn8zs6y8zu3v0s', 'IRDFF':'34sgcvt8n57b0aw'}
-	
 	if not os.path.isdir(_data_path()):
 		os.mkdir(_data_path())
 
@@ -88,7 +85,7 @@ def download(db='all', overwrite=False):
 			try:
 				print('Downloading {}'.format(fnm))
 				with open(tmp,'wb') as f:
-					f.write(urllib2.urlopen('https://www.dropbox.com/s/{0}/{1}?dl=1'.format(addr[i],fnm)).read())
+					f.write(urllib2.urlopen('https://github.com/jtmorrell/curie/releases/download/data-v1/{}'.format(fnm)).read())
 				os.replace(tmp, _data_path(fnm))
 			except Exception as e:
 				print(e)

--- a/curie/data.py
+++ b/curie/data.py
@@ -82,14 +82,18 @@ def download(db='all', overwrite=False):
 
 	for i in d:
 		fnm = i+'.db'
-		if (not os.path.isfile(_data_path(fnm))) or overwrite:
-			
+		installed = os.path.isfile(_data_path(fnm)) and os.path.getsize(_data_path(fnm))>0
+		if (not installed) or overwrite:
+			tmp = _data_path(fnm)+'.part'
 			try:
 				print('Downloading {}'.format(fnm))
-				with open(_data_path(fnm),'wb') as f:
+				with open(tmp,'wb') as f:
 					f.write(urllib2.urlopen('https://www.dropbox.com/s/{0}/{1}?dl=1'.format(addr[i],fnm)).read())
+				os.replace(tmp, _data_path(fnm))
 			except Exception as e:
-					print(e)
+				print(e)
+				if os.path.isfile(tmp):
+					os.remove(tmp)
 		else:
 			print("{0}.db already installed. Run ci.download('{0}', overwrite=True) to overwrite these files.".format(i))
 

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -141,7 +141,7 @@ class DecayChain(object):
 				if R.endswith('.json'):
 					self.R = pd.DataFrame(json.loads(open(R).read()))
 				elif R.endswith('.csv'):
-					self.R = pd.read_csv(R, header=0).fillna(method='ffill')
+					self.R = pd.read_csv(R, header=0).ffill()
 				elif R.endswith('.db'):
 					self.R = pd.read_sql('SELECT * FROM R', _get_connection(R))
 

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -498,7 +498,7 @@ class DecayChain(object):
 
 					if len(df):
 						start_time = df.iloc[0]['start_time']
-						if type(start_time)==str or type(start_time)==unicode:
+						if isinstance(start_time, str):
 							start_time = dtm.datetime.strptime(start_time, '%m/%d/%Y %H:%M:%S')
 						start = (start_time-EoB).total_seconds()*self._r_lm('s')
 						stop = start+(df.iloc[0]['real_time']*self._r_lm('s'))

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -92,7 +92,7 @@ class DecayChain(object):
 	0  1.708333  225RAg
 
 	>>> dc = ci.DecayChain('152EU', A0=3.7E3, units='h')
-	>>> print(ci.isotopes)
+	>>> print(dc.isotopes)
 	['152EUg', '152GDg', '152SMg']
 
 	"""

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -318,7 +318,7 @@ class DecayChain(object):
 				for j in range(i, L):
 					K = np.arange(i, L)
 					d_lm = lm[K[K!=j]]-lm[j]
-					C_j = np.prod(np.where(np.abs(d_lm)>1E-12, d_lm, 1E-12*np.sign(d_lm)))
+					C_j = np.prod(np.where(np.abs(d_lm)>1E-12, d_lm, np.where(d_lm>=0.0, 1E-12, -1E-12)))
 					A += A_i*B_i*np.exp(-lm[j]*time)/C_j
 					if _R_dict is not None:
 						if ip in _R_dict:
@@ -385,7 +385,7 @@ class DecayChain(object):
 				for j in range(i, len(chain)):
 					K = np.arange(i, len(chain))
 					d_lm = lm[K[K!=j]]-lm[j]
-					C_j = np.prod(np.where(np.abs(d_lm)>1E-12, d_lm, 1E-12*np.sign(d_lm)))
+					C_j = np.prod(np.where(np.abs(d_lm)>1E-12, d_lm, np.where(d_lm>=0.0, 1E-12, -1E-12)))
 					if lm[j]>1E-12:
 						D += A_i*B_i*(np.exp(-lm[j]*t_start)-np.exp(-lm[j]*t_stop))/(lm[j]*C_j)
 					else:

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -318,7 +318,10 @@ class DecayChain(object):
 				for j in range(i, L):
 					K = np.arange(i, L)
 					d_lm = lm[K[K!=j]]-lm[j]
-					C_j = np.prod(np.where(np.abs(d_lm)>1E-12, d_lm, np.where(d_lm>=0.0, 1E-12, -1E-12)))
+					# the coefficients of an exactly-tied pair are antisymmetric (d and -d), so
+					# the floor must give the two terms opposite signs (tie-break on index) for
+					# their near-singular contributions to cancel
+					C_j = np.prod(np.where(np.abs(d_lm)>1E-12, d_lm, np.where(d_lm!=0.0, 1E-12*np.sign(d_lm), np.where(K[K!=j]>j, 1E-12, -1E-12))))
 					A += A_i*B_i*np.exp(-lm[j]*time)/C_j
 					if _R_dict is not None:
 						if ip in _R_dict:
@@ -385,7 +388,10 @@ class DecayChain(object):
 				for j in range(i, len(chain)):
 					K = np.arange(i, len(chain))
 					d_lm = lm[K[K!=j]]-lm[j]
-					C_j = np.prod(np.where(np.abs(d_lm)>1E-12, d_lm, np.where(d_lm>=0.0, 1E-12, -1E-12)))
+					# the coefficients of an exactly-tied pair are antisymmetric (d and -d), so
+					# the floor must give the two terms opposite signs (tie-break on index) for
+					# their near-singular contributions to cancel
+					C_j = np.prod(np.where(np.abs(d_lm)>1E-12, d_lm, np.where(d_lm!=0.0, 1E-12*np.sign(d_lm), np.where(K[K!=j]>j, 1E-12, -1E-12))))
 					if lm[j]>1E-12:
 						D += A_i*B_i*(np.exp(-lm[j]*t_start)-np.exp(-lm[j]*t_stop))/(lm[j]*C_j)
 					else:

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -308,7 +308,7 @@ class DecayChain(object):
 					# continue
 
 				ip = self.isotopes[chain[i]]
-				A0 = self.A0[ip] if _A_dict is None else _A_dict[ip]
+				A0 = self.A0.get(ip, 0.0) if _A_dict is None else _A_dict.get(ip, 0.0)
 				if A0==0.0 and _R_dict is None:
 					continue
 				A_i = lm[-1]*(A0/lm[i])
@@ -376,7 +376,9 @@ class DecayChain(object):
 					continue
 
 				ip = self.isotopes[chain[i]]
-				A0 = self.A0[ip] if _A_dict is None else _A_dict[ip]
+				A0 = self.A0.get(ip, 0.0) if _A_dict is None else _A_dict.get(ip, 0.0)
+				if A0==0.0:
+					continue
 				A_i = lm[-1]*(A0/lm[i])
 				B_i = np.prod(lm[i:-1]*BR[i:-1])
 

--- a/curie/element.py
+++ b/curie/element.py
@@ -393,10 +393,10 @@ class Element(object):
 		--------
 		>>> el = ci.Element('Fe')
 		>>> print(el.range(60.0))
-		0.5858151125192633
+		0.5866312594085556
 		>>> el = ci.Element('U')
 		>>> print(el.range(60.0))
-		0.3763111404628591
+		0.37702082865831094
 
 		"""
 

--- a/curie/element.py
+++ b/curie/element.py
@@ -85,6 +85,8 @@ class Element(object):
 	def __init__(self, element):
 		self.name = element.title()
 		self.Z = ELEMENTS.index(self.name)
+		if self.Z>92:
+			raise ValueError('No stopping-power or attenuation data available for {} (Z={}): data covers Z=1 through Z=92 (U).'.format(self.name, self.Z))
 
 		df = pd.read_sql('SELECT * FROM weights WHERE Z={}'.format(self.Z), _get_connection('ziegler'))
 		self.mass = df['amu'][0]

--- a/curie/isotope.py
+++ b/curie/isotope.py
@@ -116,7 +116,12 @@ class Isotope(object):
 		if self.stable:
 			self.dc = 0.0
 			self.decay_products = {}
-		self.mass = float(df['amu'][0])
+		if df['amu'][0] is not None:
+			self.mass = float(df['amu'][0])
+		elif df['Delta'][0] is not None:
+			self.mass = self.A + float(df['Delta'][0])/931.49410242  # amu from mass excess
+		else:
+			self.mass = float(self.A)
 		if df['abundance'][0] is not None:
 			self.abundance = float(df['abundance'][0])
 		else:
@@ -134,9 +139,15 @@ class Isotope(object):
 
 		self._SFY = None
 
+		if not self.stable and df['half_life'][0] is None:
+			print('WARNING: {} has no half-life in the decay database, and will be treated as stable.'.format(self.name))
+			self.stable = True
+			self.dc = 0.0
+			self.decay_products = {}
+
 		if not self.stable:
 			self._t_half = float(df['half_life'][0])
-			self._unc_t_half = float(df['unc_half_life'][0])
+			self._unc_t_half = float(df['unc_half_life'][0]) if df['unc_half_life'][0] is not None else 0.0
 			self.dc = np.log(2.0)/self._t_half
 
 			self.decay_products = {}

--- a/curie/isotope.py
+++ b/curie/isotope.py
@@ -108,6 +108,8 @@ class Isotope(object):
 		self._parse_itp_name(isotope)
 
 		df = pd.read_sql('SELECT * FROM chart WHERE name="{}"'.format(self.name), _get_connection('decay'))
+		if not len(df):
+			raise ValueError('Isotope {} not found in the decay database. For a natural-abundance element, use ci.Element instead.'.format(self.name))
 		self.E_level = float(df['E_level'][0])
 		self.J_pi = str(df['J_pi'][0])
 		self.stable = bool(df['stable'][0])

--- a/curie/isotope.py
+++ b/curie/isotope.py
@@ -719,7 +719,7 @@ class Isotope(object):
 		d_unit,t_unit = tuple(units.split('/'))
 
 		if 'Sv' in d_unit:
-			dose['alpha'] = 20.0*dose['alpha']
+			dose['alphas'] = 20.0*dose['alphas']  # ICRP radiation weighting factor w_R
 			d_unit = d_unit.replace('Sv','Gy')
 
 		if t_unit in ['hr','min','yr','sec']:

--- a/curie/isotope.py
+++ b/curie/isotope.py
@@ -690,8 +690,8 @@ class Isotope(object):
 		--------
 		>>> ip = ci.Isotope('Co-60')
 		>>> print(ip.dose_rate(activity=3.7E10, units='R/hr')) # 1 Ci of Co-60 at 30 cm
-		{'beta_plus': 0.0, 'alphas': 0.0, 'gammas': 52035.28424827692, 
-		'electrons': 65.66251805557148, 'beta_minus': 5536.541902410433, 'total': 57637.488668742924}
+		{'gammas': 14.454, 'alphas': 0.0, 'beta_minus': 1545.1658,
+		'beta_plus': 0.0, 'electrons': 18.3254, 'total': 1577.9452}
 
 		"""
 

--- a/curie/library.py
+++ b/curie/library.py
@@ -237,14 +237,22 @@ class Library(object):
 		if self.db_name in ['endf','tendl','tendl_n_rp','tendl_p_rp','tendl_d_rp']:
 			table = ''.join(re.findall('[A-Z]+', target))+'_'+''.join(re.findall('[0-9]+', target))+('m' if 'm' in target else '')
 
-			return pd.read_sql('SELECT energy,{0} FROM {1}'.format(labels[0], table), self._con).to_numpy()*(np.array([1E-6, 1E3]) if self.db_name=='endf' else np.ones(2))
+			q = pd.read_sql('SELECT energy,{0} FROM {1}'.format(labels[0], table), self._con).to_numpy()*(np.array([1E-6, 1E3]) if self.db_name=='endf' else np.ones(2))
 
 		elif self.db_name=='irdff':
-			return pd.read_sql('SELECT * FROM {}'.format(labels[0]), self._con).to_numpy()*np.array([1E-6, 1E3, 1E3])
+			q = pd.read_sql('SELECT * FROM {}'.format(labels[0]), self._con).to_numpy()*np.array([1E-6, 1E3, 1E3])
 
 		elif self.db_name=='iaea_medical':
 			if incident is None:
 				raise ValueError('Incident particle must be specified.')
 			table = {'n':'neutron','p':'proton','d':'deuteron','h':'helion','a':'alpha','g':'gamma'}[incident]
-			return pd.read_sql('SELECT energy,cross_section,unc_cross_section FROM {0} WHERE target LIKE ? AND product=?'.format(table), self._con, params=('%'+target+'%', labels[0])).to_numpy()
-		
+			q = pd.read_sql('SELECT energy,cross_section,unc_cross_section FROM {0} WHERE target LIKE ? AND product=?'.format(table), self._con, params=('%'+target+'%', labels[0])).to_numpy()
+
+		if len(q):
+			# Some library tables store points out of energy order, which corrupts
+			# integration/averaging; a stable sort preserves the duplicate-energy
+			# step representation used for e.g. (n,g) reactions. Exact duplicate
+			# rows are dropped.
+			q = q[np.argsort(q[:,0], kind='stable')]
+			q = q[np.concatenate(([True], np.any(np.diff(q, axis=0)!=0.0, axis=1)))]
+		return q

--- a/curie/library.py
+++ b/curie/library.py
@@ -246,7 +246,14 @@ class Library(object):
 			if incident is None:
 				raise ValueError('Incident particle must be specified.')
 			table = {'n':'neutron','p':'proton','d':'deuteron','h':'helion','a':'alpha','g':'gamma'}[incident]
-			q = pd.read_sql('SELECT energy,cross_section,unc_cross_section FROM {0} WHERE target LIKE ? AND product=?'.format(table), self._con, params=('%'+target+'%', labels[0])).to_numpy()
+			# outgoing must be part of the filter (as in search()): some (target, product)
+			# pairs carry both a direct and a cumulative excitation function
+			sql = 'SELECT energy,cross_section,unc_cross_section FROM {0} WHERE target LIKE ? AND product=?'.format(table)
+			params = ['%'+target+'%', labels[0]]
+			if outgoing is not None:
+				sql += ' AND outgoing=?'
+				params.append(outgoing)
+			q = pd.read_sql(sql, self._con, params=tuple(params)).to_numpy()
 
 		if len(q):
 			# Some library tables store points out of energy order, which corrupts

--- a/curie/library.py
+++ b/curie/library.py
@@ -262,4 +262,8 @@ class Library(object):
 			# rows are dropped.
 			q = q[np.argsort(q[:,0], kind='stable')]
 			q = q[np.concatenate(([True], np.any(np.diff(q, axis=0)!=0.0, axis=1)))]
+			if self.db_name.startswith('tendl'):
+				# TENDL is spline-interpolated pointwise data: a duplicate abscissa is a
+				# build artifact, not a step representation, and breaks the interpolator
+				q = q[np.concatenate(([True], np.diff(q[:,0])!=0.0))]
 		return q

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -156,7 +156,7 @@ class Reaction(object):
 		--------
 		>>> rx = ci.Reaction('115IN(n,g)', 'IRDFF')
 		>>> print(rx.interpolate(0.5))
-		161.41656650941306
+		161.41646650941306
 		>>> print(rx.interpolate([0.5, 1.0, 5.0]))
 		[161.41646651 171.81486757 8.8822]
 
@@ -233,7 +233,7 @@ class Reaction(object):
 
 		Examples
 		--------
-		>>> x = ci.Reaction('Ni-58(n,p)')
+		>>> rx = ci.Reaction('Ni-58(n,p)')
 		>>> eng = np.linspace(1, 5, 20)
 		>>> phi = np.ones(20)
 		>>> print(rx.integrate(eng, phi))

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -89,22 +89,17 @@ class Reaction(object):
 
 		if library.lower()=='best':
 			if self.incident=='n':
-				for lb in ['irdff','endf','iaea','tendl','tendl_n_rp']:
-					self.library = Library(lb)
-					if lb=='tendl_n_rp':
-						self._check(True)
-					elif self._check():
-						break
+				libs = ['irdff','endf','iaea','tendl','tendl_n_rp']
 			elif self.incident in ['p','d']:
-				for lb in ['iaea','tendl_'+self.incident+'_rp']:
-					self.library = Library(lb)
-					if lb=='tendl_d_rp':
-						self._check(True)
-					elif self._check():
-						break
+				libs = ['iaea','tendl_'+self.incident+'_rp']
 			else:
-				self.library = Library('iaea')
-				self._check(True)
+				libs = ['iaea']
+			for lb in libs:
+				self.library = Library(lb)
+				if lb==libs[-1]:
+					self._check(True)
+				elif self._check():
+					break
 		else:
 			self.library = Library(library)
 			self._check(True)

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -1105,7 +1105,9 @@ class Spectrum(object):
 							'live_time':self.live_time, 'real_time':self.real_time}, columns=cols)
 
 			return p0, df
-		except:
+		except (ValueError, RuntimeError, np.linalg.LinAlgError):
+			f = p0['df']
+			print('WARNING: Peak fit failed for {0} ({1} keV)'.format(', '.join(map(str, f['isotope'])), ', '.join(map(str, f['energy']))))
 			return p0, p0['df']
 
 	def fit_peaks(self, gammas=None, **kwargs):
@@ -1232,7 +1234,10 @@ class Spectrum(object):
 		if len(p0):
 			multiplets = list(map(self._multi_fit, p0))
 			self._fits = [i[0] for i in multiplets if 'fit' in i[0]]
-			self._peaks = pd.concat([i[1] for i in multiplets if 'fit' in i[0]], ignore_index=True)
+			if len(self._fits):
+				self._peaks = pd.concat([i[1] for i in multiplets if 'fit' in i[0]], ignore_index=True)
+			else:
+				self._peaks = None
 		else:
 			self._fits = []
 			self._peaks = None

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -95,7 +95,7 @@ class Spectrum(object):
 	def __init__(self, filename=None, **kwargs):
 		self.filename = filename
 		if 'cb' in kwargs:
-			if type(kwargs['cb']==str):
+			if type(kwargs['cb'])==str:
 				self._cb = Calibration(kwargs['cb'])
 			else:
 				self._cb = copy.deepcopy(kwargs['cb'])

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -178,7 +178,7 @@ class Spectrum(object):
 			start_time = '{0}/{1}/{2} {3}:{4}:{5}'.format(months[st[2:5].lower()],st[:2],('20' if st[7]=='1' else '19')+st[5:7],st[8:10],st[10:],sts)
 			self.start_time = dtm.datetime.strptime(start_time, '%m/%d/%Y %H:%M:%S')
 
-			L = np.frombuffer(f.read(4), dtype='i2')[1]
+			L = int(np.frombuffer(f.read(4), dtype='i2')[1])
 			self.hist = np.asarray(np.frombuffer(f.read(4*L), dtype='i4'), dtype=np.int64)
 			f.read(4)
 
@@ -1342,7 +1342,9 @@ class Spectrum(object):
 			if 'SPEC_REM' in self._ortec_metadata:
 				L = min((63, len(self._ortec_metadata['SPEC_REM'][1].split('# ')[1])))
 				ss += np.array(L, dtype='i1').tobytes()
-				ss += np.array(self._ortec_metadata['SPEC_REM'][1].split('# ')[1][:L], dtype='S{}'.format(L)).tobytes()
+				if L:
+					# numpy silently promotes dtype 'S0' to 'S1' (one stray null byte)
+					ss += np.array(self._ortec_metadata['SPEC_REM'][1].split('# ')[1][:L], dtype='S{}'.format(L)).tobytes()
 				ss += np.zeros(63-L, dtype='i1').tobytes()
 			else:
 				ss += np.array(0, dtype='i1').tobytes()
@@ -1352,7 +1354,8 @@ class Spectrum(object):
 				L = len(''.join(self._ortec_metadata['SPEC_ID']))
 				L = min((63, L))
 				ss += np.array(L, dtype='i1').tobytes()
-				ss += np.array(''.join(self._ortec_metadata['SPEC_ID'])[:L], dtype='S{}'.format(L)).tobytes()
+				if L:
+					ss += np.array(''.join(self._ortec_metadata['SPEC_ID'])[:L], dtype='S{}'.format(L)).tobytes()
 				ss += np.zeros(63-L, dtype='i1').tobytes()
 			else:
 				ss += np.array(0, dtype='i1').tobytes()

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -1324,10 +1324,12 @@ class Spectrum(object):
 			ss += np.array(self.hist, dtype='i4').tobytes()
 			ss += np.array([-102, 0], dtype='i2').tobytes()
 
-			ss += np.array(self.cb.engcal, dtype='f4').tobytes()
+			engcal = list(self.cb.engcal)[:3]
+			ss += np.array(engcal+[0.0]*(3-len(engcal)), dtype='f4').tobytes()
 
 			if 'SHAPE_CAL' in self._ortec_metadata:
-				ss += np.array(self._ortec_metadata['SHAPE_CAL'][1].split(' '), dtype='f4').tobytes()
+				shapecal = self._ortec_metadata['SHAPE_CAL'][1].split(' ')[:3]
+				ss += np.array(shapecal+['0']*(3-len(shapecal)), dtype='f4').tobytes()
 			else:
 				ss += np.array([0,0,0], dtype='f4').tobytes()
 			ss += np.zeros(228, dtype='i1').tobytes()
@@ -1336,21 +1338,20 @@ class Spectrum(object):
 				L = min((63, len(self._ortec_metadata['SPEC_REM'][1].split('# ')[1])))
 				ss += np.array(L, dtype='i1').tobytes()
 				ss += np.array(self._ortec_metadata['SPEC_REM'][1].split('# ')[1][:L], dtype='S{}'.format(L)).tobytes()
+				ss += np.zeros(63-L, dtype='i1').tobytes()
 			else:
 				ss += np.array(0, dtype='i1').tobytes()
+				ss += np.zeros(63, dtype='i1').tobytes()
 
-			if 'SPEC_ID' in self._ortec_metadata:
-				if self._ortec_metadata['SPEC_ID'][0]!='No sample description was entered.':
-					L = len(''.join(self._ortec_metadata['SPEC_ID']))
-					L = min((63, L))
-					ss += np.array(L, dtype='i1').tobytes()
-					ss += np.array(''.join(self._ortec_metadata['SPEC_ID'])[:L])
-				else:
-					ss += np.array(0, dtype='i1').tobytes()
-					ss += np.array('\x00'*63, dtype='S63').tobytes()
+			if 'SPEC_ID' in self._ortec_metadata and self._ortec_metadata['SPEC_ID'][0]!='No sample description was entered.':
+				L = len(''.join(self._ortec_metadata['SPEC_ID']))
+				L = min((63, L))
+				ss += np.array(L, dtype='i1').tobytes()
+				ss += np.array(''.join(self._ortec_metadata['SPEC_ID'])[:L], dtype='S{}'.format(L)).tobytes()
+				ss += np.zeros(63-L, dtype='i1').tobytes()
 			else:
 				ss += np.array(0, dtype='i1').tobytes()
-				ss += np.array('\x00'*63, dtype='S63').tobytes()
+				ss += np.zeros(63, dtype='i1').tobytes()
 
 			ss += np.array('\x00'*128, dtype='S128').tobytes()
 			with open(filename, 'wb') as f:

--- a/curie/stack.py
+++ b/curie/stack.py
@@ -217,13 +217,13 @@ class Stack(object):
 			compounds = kwargs['compounds']
 			if type(compounds)==str:
 				if compounds.endswith('.json'):
-					df = pd.read_json(compounds, orient='records').fillna(method='ffill')
+					df = pd.read_json(compounds, orient='records').ffill()
 					df.columns = map(str.lower, map(str, df.columns))
 					cms = [str(i) for i in pd.unique(df['compound'])]
 					self.compounds = {cm:Compound(cm, weights=df[df['compound']==cm]) for cm in cms}
 
 				elif compounds.endswith('.csv'):
-					df = pd.read_csv(compounds, header=0).fillna(method='ffill')
+					df = pd.read_csv(compounds, header=0).ffill()
 					df.columns = map(str.lower, map(str, df.columns))
 					cms = [str(i) for i in pd.unique(df['compound'])]
 					self.compounds = {cm:Compound(cm, weights=df[df['compound']==cm]) for cm in cms}

--- a/curie/stack.py
+++ b/curie/stack.py
@@ -169,6 +169,7 @@ class Stack(object):
 					return 1E2*s['density']*s['thickness']
 				else:
 					return 1E2*self.compounds[s['compound']].density*s['thickness']
+			raise ValueError('Areal density of foil {} is undetermined: specify areal_density, mass and area, or thickness.'.format(s['name']))
 
 		ad = df.apply(_ad, axis=1)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = u'2024, Jonathan Morrell'
 author = u'Jonathan Morrell'
 
 # The short X.Y version
-version = u'0.0.29'
+version = u'0.0.35'
 # The full version, including alpha/beta/rc tags
-release = u'0.0.29'
+release = u'0.0.35'
 
 
 # -- General configuration ---------------------------------------------------

--- a/examples/isotope_decay_examples.py
+++ b/examples/isotope_decay_examples.py
@@ -14,7 +14,7 @@ def decay_examples():
 	### Find the scaled production rate that gives us these counts
 	dc.fit_R()
 	### Only plot the 5 most active isotopes in the decay chain
-	dc.plot(N_plot=5)
+	dc.plot(max_plot=5)
 
 
 def isotope_examples():

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='curie',
-	  version='0.0.34',
+	  version='0.0.35',
 	  description='Curie is a python toolkit to aid in the analysis of experimental nuclear data.',
 	  long_description=long_description,
 	  long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,8 @@ def _post_install(loc):
 	if not os.path.isdir(path('')):
 		os.mkdir(path(''))
 
-	for fl in ['wwd6b1gk2ge5tgt/decay.db','tkndjqs036piojm/endf.db','zkoi6t2jicc9yqs/tendl.db','x2vfjr7uv7ffex5/tendl_d_rp.db','n0jjc0dv61j9of9/tendl_n_rp.db',
-				'ib2a5lrhiwkcro5/tendl_p_rp.db','6jy0lns3vfun5vi/ziegler.db','lzn8zs6y8zu3v0s/iaea_monitors.db','34sgcvt8n57b0aw/IRDFF.db']:
-		fnm = fl.split('/')[1]
+	for fnm in ['decay.db','endf.db','tendl.db','tendl_d_rp.db','tendl_n_rp.db',
+				'tendl_p_rp.db','ziegler.db','iaea_monitors.db','IRDFF.db']:
 		if not os.path.isfile(path(fnm)):
 			try:
 				import urllib2
@@ -29,7 +28,7 @@ def _post_install(loc):
 			try:
 				print('Downloading {}'.format(fnm))
 				with open(path(fnm),'wb') as f:
-					f.write(urllib2.urlopen('https://www.dropbox.com/s/{}?dl=1'.format(fl)).read())
+					f.write(urllib2.urlopen('https://github.com/jtmorrell/curie/releases/download/data-v1/{}'.format(fnm)).read())
 			except:
 				print('ERROR: Unable to download {}. See https://jtmorrell.github.io/curie/build/html/quickinstall.html for more help.'.format(fnm))
 
@@ -57,5 +56,6 @@ setup(name='curie',
 	  # wheels/sdists: a wheel built from a dev tree with curie/data/ populated would
 	  # otherwise swallow ~1 GB of .db files (and exceed PyPI's size limit)
 	  exclude_package_data={'curie': ['data/*.db'], '': ['*.db']},
-	  cmdclass={'install': install})#,
-	  #install_requires=['numpy', 'matplotlib', 'scipy', 'pandas'])
+	  cmdclass={'install': install},
+	  python_requires='>=3.9',
+	  install_requires=['numpy', 'matplotlib', 'scipy', 'pandas'])


### PR DESCRIPTION
Crash-fix release. Every fix flips a pre-existing regression test from red to green; the public suite (72 tests) is green throughout. The branch was additionally put through a 26-agent per-commit review (implementation, simplicity, and physics lenses, findings adversarially verified) and the confirmed findings fixed or triaged before this PR.

**Crashes fixed:** `cb=` keyword with Calibration objects; `.Chn` saving (missing `tobytes()`, field padding) and reading (numpy 2 int16 overflow truncated >=8k-channel histograms); stable-isotope `activity()`/`decays()`; exactly-degenerate decay constants (now cancel antisymmetrically instead of adding to ~1E12x activities); `dose_rate` sievert units; Py2 `unicode` in `get_counts`; `Compound` `.db` round-trip; `238U` chain construction (NULL atomic masses reconstructed from mass excess); TENDL `U_235` duplicated energy point; all-peak-fits-failed; failed downloads truncating existing databases.

**Numerical callouts (old values were wrong):** `Compound.range()` integrates from 1 keV like `Element.range()` (~36% low at 2 MeV, worse below); `Library.retrieve` sorts energy grids and drops exact duplicates; IAEA reactions with both direct and cumulative channels (124Xe, 176Yb) no longer return the union of the two curves.

**Visibility:** failed peak fits print a WARNING naming isotopes/energies; clear errors for `Isotope('natFe')`, elements beyond Z=92, and foils with undetermined areal density. Known iaea_monitors data defects that only a data rebuild can fix are documented in the changelog.

**Packaging:** all data downloads repointed from Dropbox to the immutable data-v1 release assets (verified live, SHA256 match); `install_requires` + `python_requires>=3.9`; version bumped; CHANGELOG.md added.

The authors acknowledge the assistance of Claude, an AI model provided by Anthropic, in the writing of this software.