### PR TITLE
Numerics release 0.0.36: corrected results, confluent Bateman solution, uncertainty model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Notable changes to curie are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased] - 0.0.36
+
+Numerics-focused release: where 0.0.35 fixed crashes, 0.0.36 corrects numbers.
+Changed results are called out below with their magnitude and reason —
+re-check analyses that depend on them.
+
 ## [0.0.35] - 2026-07-01
 
 Crash-fix (hotfix) release. Two fixes change numerical results; they are called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,16 @@ re-check analyses that depend on them. A before/after benchmark (the shipped
 summarized per item.
 
 ### Changed — numerical results
-- **Activity/decay uncertainties no longer double-count the Poisson term.**
-  The peak-fit covariance (weighted least squares with sigma=sqrt(counts))
-  already carries the full counting statistics of the fitted area — verified
-  analytically and by Monte Carlo — so the extra 1/N term in `unc_decays` was
-  a duplicate. Uncertainties shrink by up to sqrt(2) for statistics-dominated
-  peaks (benchmark: -1.2% to -10.2% on the 152Eu lines). Central values are
-  unchanged.
+- **Activity/decay uncertainties no longer double-count the Poisson term,
+  and the fit covariance now respects the counting floor.** The peak-fit
+  covariance (weighted least squares with sigma=sqrt(counts)) already carries
+  the full counting statistics of the fitted area — verified analytically and
+  by Monte Carlo — so the extra 1/N term in `unc_decays` was a duplicate.
+  The covariance is now absolute (`absolute_sigma=True`) with a one-sided
+  scale factor: inflated by chi2/dof when above 1 (model mismatch, as
+  before), but no longer deflated below the sqrt(N) counting floor when a
+  clean low-background peak fits with chi2/dof < 1. Benchmark: -0.3% to
+  -9.8% on the 152Eu lines. Central values are unchanged.
 - **Un-resolvable gamma lines are now actually merged.** The intensity
   combination in `Spectrum._gammas` silently discarded the merged intensity
   (pandas chained assignment) and left triplets partially merged. Decays and
@@ -26,8 +29,8 @@ summarized per item.
   the 152Eu 719.3 keV pair's combined intensity rises 38%, its inferred
   decays drop 27.5%; the eu fit_R production rate moves -0.8%).
 - **No cross-section extrapolation beyond the evaluated grid** (`Reaction.
-  interpolate` returns 0 off-grid for all libraries; ENDF/IRDFF previously
-  extrapolated linearly). Threshold reactions queried off-grid stop returning
+  interpolate` returns 0 off-grid for all libraries; ENDF, IRDFF, and the
+  IAEA monitors previously extrapolated linearly). Threshold reactions queried off-grid stop returning
   fabricated values (90Zr(n,2n) at 30 MeV: 903.7 mb -> 0), and flux averages
   over windows extending past a grid edge lose the fabricated contribution
   (natTi(p,x)46Sc averaged over 40-95 MeV vs its 80 MeV grid ceiling: -22%).
@@ -49,6 +52,13 @@ summarized per item.
   keeps the partial-fraction products inside float64 for any time units
   (previously up to 1E302 in 1/Gy on the deep 238U branches) and makes
   activities unit-invariant at machine precision.
+- **`decays()` is correct for slow members at long times.** The
+  small-decay-constant branch selected the linear-in-time limit on lambda
+  alone, but the expansion parameter is lambda*t: interior members of the
+  extended 238U series (234U, 230Th, 226Ra) at geological times returned
+  sign-wrong, orders-of-magnitude-wrong decay counts. The exponential
+  differences are now evaluated with expm1, exact for every lambda, with no
+  threshold branch (verified against direct integration of the activity).
 
 ### Fixed
 - `.Spe` saving no longer truncates live/real times to whole seconds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,73 @@
 Notable changes to curie are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased] - 0.0.36
+## [0.0.36] - 2026-07-03
 
 Numerics-focused release: where 0.0.35 fixed crashes, 0.0.36 corrects numbers.
 Changed results are called out below with their magnitude and reason —
-re-check analyses that depend on them.
+re-check analyses that depend on them. A before/after benchmark (the shipped
+152Eu spectrum end-to-end, plus the affected reactions and chains) is
+summarized per item.
+
+### Changed — numerical results
+- **Activity/decay uncertainties no longer double-count the Poisson term.**
+  The peak-fit covariance (weighted least squares with sigma=sqrt(counts))
+  already carries the full counting statistics of the fitted area — verified
+  analytically and by Monte Carlo — so the extra 1/N term in `unc_decays` was
+  a duplicate. Uncertainties shrink by up to sqrt(2) for statistics-dominated
+  peaks (benchmark: -1.2% to -10.2% on the 152Eu lines). Central values are
+  unchanged.
+- **Un-resolvable gamma lines are now actually merged.** The intensity
+  combination in `Spectrum._gammas` silently discarded the merged intensity
+  (pandas chained assignment) and left triplets partially merged. Decays and
+  decay rates derived from merged multiplets change accordingly (benchmark:
+  the 152Eu 719.3 keV pair's combined intensity rises 38%, its inferred
+  decays drop 27.5%; the eu fit_R production rate moves -0.8%).
+- **No cross-section extrapolation beyond the evaluated grid** (`Reaction.
+  interpolate` returns 0 off-grid for all libraries; ENDF/IRDFF previously
+  extrapolated linearly). Threshold reactions queried off-grid stop returning
+  fabricated values (90Zr(n,2n) at 30 MeV: 903.7 mb -> 0), and flux averages
+  over windows extending past a grid edge lose the fabricated contribution
+  (natTi(p,x)46Sc averaged over 40-95 MeV vs its 80 MeV grid ceiling: -22%).
+- **Exactly and nearly equal decay constants use the confluent Bateman
+  solution.** Chain members with relatively indistinguishable decay constants
+  (below 1E-9) are evaluated with the exact degenerate-eigenvalue terms
+  (t*exp(-lt) for a pair), replacing the 1E-12 floor. Real database ties
+  (e.g. 154Hf->154Lu, both stored as 2.0 s) now give the analytic in-growth
+  instead of 0.
+- **Decay-chain composition is unit-independent and extends to true
+  stability.** The chain-expansion cutoff compared decay constants to 1E-12
+  in the user's time units, so chains depended on `units=` (99Ru dropped for
+  'ns'; the 238U series never passed 234U for 's'). Chains now include all
+  unstable members in every unit; long-lived members appear with
+  correspondingly small activities, and e.g. the 152Eu chain now continues
+  past 152Gd (1.1E14 y) to 140Ce.
+- **Bateman evaluation is rescaled per branch** (decay constants divided by
+  their geometric mean, time scaled inversely — an exact invariance). This
+  keeps the partial-fraction products inside float64 for any time units
+  (previously up to 1E302 in 1/Gy on the deep 238U branches) and makes
+  activities unit-invariant at machine precision.
+
+### Fixed
+- `.Spe` saving no longer truncates live/real times to whole seconds.
+- The IEC reader no longer loses a final-line count value ending in 0 or 4.
+- An all-zero spectrum (valid input) no longer crashes at construction.
+- `_chi2` returns inf instead of a negative value for over-parameterized
+  fit windows.
+- `map_channel` raises a clear ValueError for non-invertible energy
+  calibrations (zero slope, negative discriminant) instead of returning
+  garbage int32 channels.
+- The chemical-formula parser aggregates repeated elements (CH3OH gave two
+  H rows).
+- `Element._eff_Z_ratio` no longer raises NameError for protons when called
+  directly.
+- Chain deduplication uses a tuple key (string-join collided for two-digit
+  member indices); `fit_R`/`fit_A0` bounds no longer produce NaN for a zero
+  initial guess.
+- `Isotope('Fe')` (bare element symbol) raises the natural-element guidance
+  instead of an opaque parse error; isomer masses reconstructed from the
+  mass excess use the ground-state convention; counts assigned to a stable
+  isotope raise a clear ValueError; `cb=None` yields a default Calibration.
 
 ## [0.0.35] - 2026-07-01
 

--- a/curie/__init__.py
+++ b/curie/__init__.py
@@ -53,7 +53,7 @@ from .reaction import Reaction
 
 from .stack import Stack
 
-__version__ = '0.0.35'
+__version__ = '0.0.36'
 __all__ = ['download', 'colormap', 'set_style', 
           'Isotope', 'Element', 'Compound', 
           'Spectrum', 'Calibration', 'DecayChain', 

--- a/curie/calibration.py
+++ b/curie/calibration.py
@@ -469,8 +469,13 @@ class Calibration(object):
 
 		if len(engcal)==3:
 			if engcal[2]!=0.0:
-				return np.array(np.rint(0.5*(np.sqrt(engcal[1]**2-4.0*engcal[2]*(engcal[0]-energy))-engcal[1])/engcal[2]), dtype=np.int32)
+				disc = engcal[1]**2-4.0*engcal[2]*(engcal[0]-energy)
+				if np.any(disc<0.0):
+					raise ValueError('Energy calibration {0} cannot be inverted at energy {1} (negative discriminant).'.format(list(engcal), np.atleast_1d(energy)[np.atleast_1d(disc<0.0)].tolist()))
+				return np.array(np.rint(0.5*(np.sqrt(disc)-engcal[1])/engcal[2]), dtype=np.int32)
 
+		if engcal[1]==0.0:
+			raise ValueError('Energy calibration {} cannot be inverted (zero slope).'.format(list(engcal)))
 		return np.array(np.rint((energy-engcal[0])/engcal[1]), dtype=np.int32)
 		
 	def calibrate(self, spectra, sources):

--- a/curie/compound.py
+++ b/curie/compound.py
@@ -138,7 +138,10 @@ class Compound(object):
 			if all([e in ELEMENTS for e in elements]):
 				wts = re.split('|'.join(sorted(elements, key=lambda i:-len(i))), compound)
 				atom_weights = np.array([float(wts[n+1]) if wts[n+1] else 1.0 for n,e in enumerate(elements)])
-				self._set_weights(elements, atom_weights=atom_weights)
+				# aggregate repeated elements (e.g. both H groups in CH3OH) into one row each
+				unique_elements = list(dict.fromkeys(elements))
+				atom_weights = np.array([sum(w for e,w in zip(elements, atom_weights) if e==u) for u in unique_elements])
+				self._set_weights(unique_elements, atom_weights=atom_weights)
 
 		if weights is not None:
 

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -87,14 +87,14 @@ class DecayChain(object):
 	--------
 	>>> dc = ci.DecayChain('Ra-225', R=[[1.0, 1.0], [0.5, 1.5], [2.0, 6]], units='d')
 	>>> print(dc.isotopes)
-	['225RAg', '225ACg', '221FRg', '217ATg', '213BIg', '217RNg', '209TLg', '213POg', '209PBg', '209BIg']
+	['225RAg', '225ACg', '221FRg', '217ATg', '213BIg', '217RNg', '209TLg', '213POg', '209PBg', '209BIg', '205TLg']
 	>>> print(dc.R_avg)
           R_avg isotope
 	0  1.708333  225RAg
 
 	>>> dc = ci.DecayChain('152EU', A0=3.7E3, units='h')
 	>>> print(dc.isotopes)
-	['152EUg', '152GDg', '152SMg']
+	['152EUg', '152GDg', '152SMg', '148SMg', '144NDg', '140CEg']
 
 	"""
 

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -496,10 +496,11 @@ class DecayChain(object):
 										'unc_counts':ct[:,3]})
 					self._counts = pd.concat([self._counts, ct], ignore_index=True).reset_index(drop=True)
 
-			for n,p in self._counts.iterrows():
-				if float(self.decays(p['isotope'], p['start'], p['stop']))==0.0:
+			dcy = [float(self.decays(p['isotope'], p['start'], p['stop'])) for n,p in self._counts.iterrows()]
+			for d,(n,p) in zip(dcy, self._counts.iterrows()):
+				if d==0.0:
 					raise ValueError('Cannot assign counts to {}: no decays in the given interval (stable isotope, or zero activity).'.format(p['isotope']))
-			self._counts['activity'] = [p['counts']*self.activity(p['isotope'], p['start'])/self.decays(p['isotope'], p['start'], p['stop']) for n,p in self._counts.iterrows()]
+			self._counts['activity'] = [p['counts']*self.activity(p['isotope'], p['start'])/d for d,(n,p) in zip(dcy, self._counts.iterrows())]
 			self._counts['unc_activity'] = self._counts['unc_counts']*self.counts['activity']/self._counts['counts']
 			
 		

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -300,7 +300,7 @@ class DecayChain(object):
 			lm = self._r_lm(units)*self._chain[chain, 0]
 			L = len(chain)
 			for i in range(L):
-				sub = ''.join(map(str, chain[i:]))
+				sub = tuple(chain[i:])
 				if sub in finished:
 					continue
 				finished.append(sub)

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -122,7 +122,9 @@ class DecayChain(object):
 						istps.append(I)
 						self.isotopes.append(I.name)
 						self._chain.append([I.decay_const(units), [br], [n]])
-						stable_chain.append(self._chain[-1][0]<1E-12)
+						# chain expansion stops only at truly stable members, so chain
+						# composition is independent of the chosen time units
+						stable_chain.append(I.stable)
 						if not stable_chain[-1]:
 							self.A0[self.isotopes[-1]] = 0.0
 		self._chain = np.array(self._chain, dtype=object)
@@ -778,7 +780,7 @@ class DecayChain(object):
 
 		plot_time = time if self.R is None else np.append(T_grid-T_grid[-1], time.copy())
 		for n,istp in enumerate(self.isotopes):
-			if self._chain[n,0]>1E-12 and n<max_plot:
+			if self._chain[n,0]>1E-12*self._r_lm(self.units, True) and n<max_plot:
 				A = self.activity(istp, time)
 				if self.R is not None:
 					A = np.append(A_grid[istp], A)

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -605,7 +605,7 @@ class DecayChain(object):
 		p0 = np.where((p0>0)&(np.isfinite(p0)), p0, 1.0)
 
 		func = lambda X_f, *R_f: np.dot(np.asarray(R_f), X_f)
-		fit, cov = curve_fit(func, X, Y, sigma=dY, p0=p0, bounds=(0.0*p0, np.inf*p0))
+		fit, cov = curve_fit(func, X, Y, sigma=dY, p0=p0, bounds=(0.0, np.inf))
 
 
 		for n,ip in enumerate(R_isotopes):
@@ -684,7 +684,7 @@ class DecayChain(object):
 
 		func = lambda X_f, *R_f: np.dot(np.asarray(R_f), X_f)
 		p0 = np.ones(len(X))
-		fit, cov = curve_fit(func, X, Y, sigma=dY, p0=p0, bounds=(0.0*p0, np.inf*p0))
+		fit, cov = curve_fit(func, X, Y, sigma=dY, p0=p0, bounds=(0.0, np.inf))
 
 		for n,ip in enumerate(A0_isotopes):
 			self.A0[ip] *= fit[n]

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -431,6 +431,9 @@ class DecayChain(object):
 										'unc_counts':ct[:,3]})
 					self._counts = pd.concat([self._counts, ct], ignore_index=True).reset_index(drop=True)
 
+			for n,p in self._counts.iterrows():
+				if float(self.decays(p['isotope'], p['start'], p['stop']))==0.0:
+					raise ValueError('Cannot assign counts to {}: no decays in the given interval (stable isotope, or zero activity).'.format(p['isotope']))
 			self._counts['activity'] = [p['counts']*self.activity(p['isotope'], p['start'])/self.decays(p['isotope'], p['start'], p['stop']) for n,p in self._counts.iterrows()]
 			self._counts['unc_activity'] = self._counts['unc_counts']*self.counts['activity']/self._counts['counts']
 			

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import math
 import numpy as np
 import pandas as pd
 import datetime as dtm
@@ -238,6 +239,50 @@ class DecayChain(object):
 					br_ratios.append(np.array(self._branches[1][n][:k] + [0.0]))
 		return br_ratios, branches
 
+	@staticmethod
+	def _lm_clusters(lm):
+		# Group indistinguishable decay constants (pairwise relative separation
+		# below 1E-9): the standard partial-fraction Bateman coefficients are
+		# singular for (near-)equal pairs, which occur in the database as
+		# identically rounded half-lives. Relative comparison keeps the grouping
+		# unit-independent.
+		clusters = []
+		for j in range(len(lm)):
+			for cl in clusters:
+				if abs(lm[j]-lm[cl[0]])<=1E-9*max(abs(lm[j]), abs(lm[cl[0]])):
+					cl.append(j)
+					break
+			else:
+				clusters.append([j])
+		return clusters
+
+	@staticmethod
+	def _confluent_dd(m, lam, others, time, inv_lam):
+		# (-1)^(m-1)/(m-1)! * (d/dlam)^(m-1) of exp(-lam*time)/(lam^inv_lam * P(lam)),
+		# with P(lam) = prod(others-lam): the exact confluent Bateman coefficient for
+		# a cluster of m equal decay constants (the divided difference of the
+		# partial-fraction terms collapses to this derivative as the constants
+		# coincide). Evaluated with the logarithmic-derivative recursion
+		# f^(k) = sum_r C(k-1,r-1) * (ln f)^(r) * f^(k-r), which is free of the
+		# catastrophic cancellation of the raw partial-fraction sum.
+		P = np.prod(others-lam) if len(others) else 1.0
+		f = np.exp(-lam*time)/((lam if inv_lam else 1.0)*P)
+		if m==1:
+			return f
+		w = [None]*m
+		for r in range(1, m):
+			w[r] = math.factorial(r-1)*(np.sum(1.0/(others-lam)**r) if len(others) else 0.0)
+			if inv_lam:
+				w[r] += (-1.0)**r*math.factorial(r-1)/lam**r
+		w[1] = w[1]-time
+		g = [f]
+		for k in range(1, m):
+			s = 0.0
+			for r in range(1, k+1):
+				s = s+math.comb(k-1, r-1)*w[r]*g[k-r]
+			g.append(s)
+		return (-1.0)**(m-1)/math.factorial(m-1)*g[m-1]
+
 	def _r_lm(self, units=None, r_half_conv=False):
 		if units is None:
 			return 1.0
@@ -297,9 +342,13 @@ class DecayChain(object):
 		time = np.asarray(time)
 		A = np.zeros(len(time)) if time.shape else np.array(0.0)
 
+		# smallest decay constant treated as nonzero, fixed at 1E-12 1/s and
+		# expressed in the evaluation units so behavior is unit-independent
+		thr = 1E-12*self._r_lm((self.units if units is None else units), True)
+
 		finished = []
 		for m,(BR, chain) in enumerate(zip(*self._get_branches(isotope))):
-			lm = self._r_lm(units)*self._chain[chain, 0]
+			lm = np.asarray(self._r_lm(units)*self._chain[chain, 0], dtype=np.float64)
 			L = len(chain)
 			for i in range(L):
 				sub = tuple(chain[i:])
@@ -311,26 +360,24 @@ class DecayChain(object):
 
 				ip = self.isotopes[chain[i]]
 				A0 = self.A0.get(ip, 0.0) if _A_dict is None else _A_dict.get(ip, 0.0)
-				if A0==0.0 and _R_dict is None:
+				if A0==0.0 and (_R_dict is None or lm[i]==0.0):
 					continue
 				A_i = lm[-1]*(A0/lm[i])
-				
+
 				B_i = np.prod(lm[i:-1]*BR[i:-1])
 
-				for j in range(i, L):
-					K = np.arange(i, L)
-					d_lm = lm[K[K!=j]]-lm[j]
-					# the coefficients of an exactly-tied pair are antisymmetric (d and -d), so
-					# the floor must give the two terms opposite signs (tie-break on index) for
-					# their near-singular contributions to cancel
-					C_j = np.prod(np.where(np.abs(d_lm)>1E-12, d_lm, np.where(d_lm!=0.0, 1E-12*np.sign(d_lm), np.where(K[K!=j]>j, 1E-12, -1E-12))))
-					A += A_i*B_i*np.exp(-lm[j]*time)/C_j
+				lms = lm[i:]
+				for cl in self._lm_clusters(lms):
+					lam, mc = np.mean(lms[cl]), len(cl)
+					others = np.array([lms[k] for k in range(len(lms)) if k not in cl])
+					A += A_i*B_i*self._confluent_dd(mc, lam, others, time, False)
 					if _R_dict is not None:
 						if ip in _R_dict:
-							if lm[j]>1E-12:
-								A += _R_dict[ip]*lm[-1]*B_i*(1.0-np.exp(-lm[j]*time))/(lm[j]*C_j)
+							if lam>thr:
+								A += _R_dict[ip]*lm[-1]*B_i*(self._confluent_dd(mc, lam, others, 0.0, True)-self._confluent_dd(mc, lam, others, time, True))
 							else:
-								A += _R_dict[ip]*lm[-1]*B_i*time/C_j
+								C = np.prod(others-lam) if len(others) else 1.0
+								A += _R_dict[ip]*lm[-1]*B_i*time/C
 		return A
 		
 	def decays(self, isotope, t_start, t_stop, units=None, _A_dict=None):
@@ -373,8 +420,10 @@ class DecayChain(object):
 		t_start, t_stop = np.asarray(t_start), np.asarray(t_stop)
 		D = np.zeros(len(t_start)) if t_start.shape else (np.zeros(len(t_stop)) if t_stop.shape else np.array(0.0))
 
+		thr = 1E-12*self._r_lm((self.units if units is None else units), True)
+
 		for m,(BR, chain) in enumerate(zip(*self._get_branches(isotope))):
-			lm = self._r_lm(units)*self._chain[chain,0]
+			lm = np.asarray(self._r_lm(units)*self._chain[chain,0], dtype=np.float64)
 			L = len(chain)
 			for i in range(L):
 				if i==L-1 and m>0:
@@ -387,17 +436,15 @@ class DecayChain(object):
 				A_i = lm[-1]*(A0/lm[i])
 				B_i = np.prod(lm[i:-1]*BR[i:-1])
 
-				for j in range(i, len(chain)):
-					K = np.arange(i, len(chain))
-					d_lm = lm[K[K!=j]]-lm[j]
-					# the coefficients of an exactly-tied pair are antisymmetric (d and -d), so
-					# the floor must give the two terms opposite signs (tie-break on index) for
-					# their near-singular contributions to cancel
-					C_j = np.prod(np.where(np.abs(d_lm)>1E-12, d_lm, np.where(d_lm!=0.0, 1E-12*np.sign(d_lm), np.where(K[K!=j]>j, 1E-12, -1E-12))))
-					if lm[j]>1E-12:
-						D += A_i*B_i*(np.exp(-lm[j]*t_start)-np.exp(-lm[j]*t_stop))/(lm[j]*C_j)
+				lms = lm[i:]
+				for cl in self._lm_clusters(lms):
+					lam, mc = np.mean(lms[cl]), len(cl)
+					others = np.array([lms[k] for k in range(len(lms)) if k not in cl])
+					if lam>thr:
+						D += A_i*B_i*(self._confluent_dd(mc, lam, others, t_start, True)-self._confluent_dd(mc, lam, others, t_stop, True))
 					else:
-						D += A_i*B_i*(t_stop-t_start)/C_j
+						C = np.prod(others-lam) if len(others) else 1.0
+						D += A_i*B_i*(t_stop-t_start)/C
 
 		return D*self._r_lm((self.units if units is None else units), True)
 

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -342,10 +342,6 @@ class DecayChain(object):
 		time = np.asarray(time)
 		A = np.zeros(len(time)) if time.shape else np.array(0.0)
 
-		# smallest decay constant treated as nonzero, fixed at 1E-12 1/s and
-		# expressed in the evaluation units so behavior is unit-independent
-		thr = 1E-12*self._r_lm((self.units if units is None else units), True)
-
 		finished = []
 		for m,(BR, chain) in enumerate(zip(*self._get_branches(isotope))):
 			lm = np.asarray(self._r_lm(units)*self._chain[chain, 0], dtype=np.float64)
@@ -355,7 +351,7 @@ class DecayChain(object):
 			# products near unity and keeps long chains inside float64 range in
 			# any choice of time units
 			sc = np.exp(np.mean(np.log(lm[lm>0]))) if np.any(lm>0) else 1.0
-			lm_s, time_s, thr_s = lm/sc, time*sc, thr/sc
+			lm_s, time_s = lm/sc, time*sc
 			for i in range(L):
 				sub = tuple(chain[i:])
 				if sub in finished:
@@ -379,11 +375,16 @@ class DecayChain(object):
 					A += A_i*B_i*self._confluent_dd(mc, lam, others, time_s, False)
 					if _R_dict is not None:
 						if ip in _R_dict:
-							if lam>thr_s:
-								A += _R_dict[ip]*lm_s[-1]*B_i*(self._confluent_dd(mc, lam, others, 0.0, True)-self._confluent_dd(mc, lam, others, time_s, True))
-							else:
+							if mc==1:
+								# expm1 makes (1-exp(-lam*t))/lam exact for every lam*t,
+								# with no threshold branch; lam==0 is the exact limit t
 								C = np.prod(others-lam) if len(others) else 1.0
-								A += _R_dict[ip]*lm_s[-1]*B_i*time_s/C
+								if lam==0.0:
+									A += _R_dict[ip]*lm_s[-1]*B_i*time_s/C
+								else:
+									A += _R_dict[ip]*lm_s[-1]*B_i*(-np.expm1(-lam*time_s))/(lam*C)
+							else:
+								A += _R_dict[ip]*lm_s[-1]*B_i*(self._confluent_dd(mc, lam, others, 0.0, True)-self._confluent_dd(mc, lam, others, time_s, True))
 		return A
 		
 	def decays(self, isotope, t_start, t_stop, units=None, _A_dict=None):
@@ -426,15 +427,13 @@ class DecayChain(object):
 		t_start, t_stop = np.asarray(t_start), np.asarray(t_stop)
 		D = np.zeros(len(t_start)) if t_start.shape else (np.zeros(len(t_stop)) if t_stop.shape else np.array(0.0))
 
-		thr = 1E-12*self._r_lm((self.units if units is None else units), True)
-
 		for m,(BR, chain) in enumerate(zip(*self._get_branches(isotope))):
 			lm = np.asarray(self._r_lm(units)*self._chain[chain,0], dtype=np.float64)
 			L = len(chain)
 			# branch-wise rescale as in activity(); the decay integral carries one
 			# net power of time, so each rescaled term is divided by sc
 			sc = np.exp(np.mean(np.log(lm[lm>0]))) if np.any(lm>0) else 1.0
-			lm_s, t1_s, t2_s, thr_s = lm/sc, t_start*sc, t_stop*sc, thr/sc
+			lm_s, t1_s, t2_s = lm/sc, t_start*sc, t_stop*sc
 			for i in range(L):
 				if i==L-1 and m>0:
 					continue
@@ -450,11 +449,18 @@ class DecayChain(object):
 				for cl in self._lm_clusters(lms):
 					lam, mc = np.mean(lms[cl]), len(cl)
 					others = np.array([lms[k] for k in range(len(lms)) if k not in cl])
-					if lam>thr_s:
-						D += A_i*B_i*(self._confluent_dd(mc, lam, others, t1_s, True)-self._confluent_dd(mc, lam, others, t2_s, True))/sc
-					else:
+					if mc==1:
+						# expm1 makes (exp(-lam*t1)-exp(-lam*t2))/lam exact for every
+						# lam*t - a threshold branch on lam alone misclassifies slow
+						# members at long times, where lam*t is order unity even though
+						# lam is tiny; lam==0 is the exact linear limit
 						C = np.prod(others-lam) if len(others) else 1.0
-						D += A_i*B_i*(t2_s-t1_s)/(C*sc)
+						if lam==0.0:
+							D += A_i*B_i*(t2_s-t1_s)/(C*sc)
+						else:
+							D += A_i*B_i*np.exp(-lam*t1_s)*(-np.expm1(-lam*(t2_s-t1_s)))/(lam*C*sc)
+					else:
+						D += A_i*B_i*(self._confluent_dd(mc, lam, others, t1_s, True)-self._confluent_dd(mc, lam, others, t2_s, True))/sc
 
 		return D*self._r_lm((self.units if units is None else units), True)
 

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -350,6 +350,12 @@ class DecayChain(object):
 		for m,(BR, chain) in enumerate(zip(*self._get_branches(isotope))):
 			lm = np.asarray(self._r_lm(units)*self._chain[chain, 0], dtype=np.float64)
 			L = len(chain)
+			# every Bateman term is invariant under (lm, t) -> (lm/sc, t*sc), so a
+			# branch-wise geometric-mean rescale centers the partial-fraction
+			# products near unity and keeps long chains inside float64 range in
+			# any choice of time units
+			sc = np.exp(np.mean(np.log(lm[lm>0]))) if np.any(lm>0) else 1.0
+			lm_s, time_s, thr_s = lm/sc, time*sc, thr/sc
 			for i in range(L):
 				sub = tuple(chain[i:])
 				if sub in finished:
@@ -362,22 +368,22 @@ class DecayChain(object):
 				A0 = self.A0.get(ip, 0.0) if _A_dict is None else _A_dict.get(ip, 0.0)
 				if A0==0.0 and (_R_dict is None or lm[i]==0.0):
 					continue
-				A_i = lm[-1]*(A0/lm[i])
+				A_i = lm_s[-1]*(A0/lm_s[i])
 
-				B_i = np.prod(lm[i:-1]*BR[i:-1])
+				B_i = np.prod(lm_s[i:-1]*BR[i:-1])
 
-				lms = lm[i:]
+				lms = lm_s[i:]
 				for cl in self._lm_clusters(lms):
 					lam, mc = np.mean(lms[cl]), len(cl)
 					others = np.array([lms[k] for k in range(len(lms)) if k not in cl])
-					A += A_i*B_i*self._confluent_dd(mc, lam, others, time, False)
+					A += A_i*B_i*self._confluent_dd(mc, lam, others, time_s, False)
 					if _R_dict is not None:
 						if ip in _R_dict:
-							if lam>thr:
-								A += _R_dict[ip]*lm[-1]*B_i*(self._confluent_dd(mc, lam, others, 0.0, True)-self._confluent_dd(mc, lam, others, time, True))
+							if lam>thr_s:
+								A += _R_dict[ip]*lm_s[-1]*B_i*(self._confluent_dd(mc, lam, others, 0.0, True)-self._confluent_dd(mc, lam, others, time_s, True))
 							else:
 								C = np.prod(others-lam) if len(others) else 1.0
-								A += _R_dict[ip]*lm[-1]*B_i*time/C
+								A += _R_dict[ip]*lm_s[-1]*B_i*time_s/C
 		return A
 		
 	def decays(self, isotope, t_start, t_stop, units=None, _A_dict=None):
@@ -425,6 +431,10 @@ class DecayChain(object):
 		for m,(BR, chain) in enumerate(zip(*self._get_branches(isotope))):
 			lm = np.asarray(self._r_lm(units)*self._chain[chain,0], dtype=np.float64)
 			L = len(chain)
+			# branch-wise rescale as in activity(); the decay integral carries one
+			# net power of time, so each rescaled term is divided by sc
+			sc = np.exp(np.mean(np.log(lm[lm>0]))) if np.any(lm>0) else 1.0
+			lm_s, t1_s, t2_s, thr_s = lm/sc, t_start*sc, t_stop*sc, thr/sc
 			for i in range(L):
 				if i==L-1 and m>0:
 					continue
@@ -433,18 +443,18 @@ class DecayChain(object):
 				A0 = self.A0.get(ip, 0.0) if _A_dict is None else _A_dict.get(ip, 0.0)
 				if A0==0.0:
 					continue
-				A_i = lm[-1]*(A0/lm[i])
-				B_i = np.prod(lm[i:-1]*BR[i:-1])
+				A_i = lm_s[-1]*(A0/lm_s[i])
+				B_i = np.prod(lm_s[i:-1]*BR[i:-1])
 
-				lms = lm[i:]
+				lms = lm_s[i:]
 				for cl in self._lm_clusters(lms):
 					lam, mc = np.mean(lms[cl]), len(cl)
 					others = np.array([lms[k] for k in range(len(lms)) if k not in cl])
-					if lam>thr:
-						D += A_i*B_i*(self._confluent_dd(mc, lam, others, t_start, True)-self._confluent_dd(mc, lam, others, t_stop, True))
+					if lam>thr_s:
+						D += A_i*B_i*(self._confluent_dd(mc, lam, others, t1_s, True)-self._confluent_dd(mc, lam, others, t2_s, True))/sc
 					else:
 						C = np.prod(others-lam) if len(others) else 1.0
-						D += A_i*B_i*(t_stop-t_start)/C
+						D += A_i*B_i*(t2_s-t1_s)/(C*sc)
 
 		return D*self._r_lm((self.units if units is None else units), True)
 

--- a/curie/element.py
+++ b/curie/element.py
@@ -290,7 +290,7 @@ class Element(object):
 
 	def _eff_Z_ratio(self, E_keV, z1, M1):
 		if z1==1:
-			return np.ones(len(eng))
+			return np.ones(len(E_keV))
 
 		elif z1==2:
 			Y = np.log(E_keV/M1)

--- a/curie/isotope.py
+++ b/curie/isotope.py
@@ -190,6 +190,8 @@ class Isotope(object):
 			self.element = ''.join(re.findall('[A-Z]+', istp)).title()
 			if istp.startswith('nat'):
 				self.A = 'nat'
+			elif not istp.split(self.element.upper())[0]:
+				raise ValueError('Isotope name {} has no mass number: use e.g. 60CO or Co-60, or ci.Element for a natural-abundance element.'.format(istp))
 			else:
 				self.A = int(istp.split(self.element.upper())[0])
 

--- a/curie/isotope.py
+++ b/curie/isotope.py
@@ -119,7 +119,9 @@ class Isotope(object):
 		if df['amu'][0] is not None:
 			self.mass = float(df['amu'][0])
 		elif df['Delta'][0] is not None:
-			self.mass = self.A + float(df['Delta'][0])/931.49410242  # amu from mass excess
+			# Delta is the level mass excess (includes E_level); the amu column
+			# convention is the ground-state mass for isomers
+			self.mass = self.A + (float(df['Delta'][0])-self.E_level)/931.49410242
 		else:
 			self.mass = float(self.A)
 		if df['abundance'][0] is not None:

--- a/curie/reaction.py
+++ b/curie/reaction.py
@@ -140,7 +140,8 @@ class Reaction(object):
 		"""Interpolated cross section
 
 		Linear interpolation of the reaction cross section along the
-		input energy grid.
+		input energy grid.  Energies outside the evaluated grid return 0
+		rather than an extrapolation.
 
 		Parameters
 		----------
@@ -164,7 +165,7 @@ class Reaction(object):
 
 		if self._interp is None:
 			kind = 'linear'
-			fv = 'extrapolate'
+			fv = 0.0
 			i = 0
 			if self.library.name.lower().startswith('tendl'):
 				kind = 'quadratic'

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -1289,7 +1289,7 @@ class Spectrum(object):
 		if filename.endswith('.Spe'):
 			### Maestro ASCII .Spe ###
 			self._ortec_metadata['DATE_MEA'] = [dtm.datetime.strftime(self.start_time, '%m/%d/%Y %H:%M:%S')]
-			self._ortec_metadata['MEAS_TIM'] = ['{0} {1}'.format(int(self.live_time), int(self.real_time))]
+			self._ortec_metadata['MEAS_TIM'] = ['{0} {1}'.format(self.live_time, self.real_time)]
 
 			self._ortec_metadata['ENER_FIT'] = ['{0} {1}'.format(self.cb.engcal[0], self.cb.engcal[1])]
 			self._ortec_metadata['MCA_CAL'] = ['3','{0} {1} {2} keV'.format(self.cb.engcal[0], self.cb.engcal[1], (self.cb.engcal[2] if len(self.cb.engcal)>2 else 0.0))]

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -680,7 +680,7 @@ class Spectrum(object):
 
 		x, dead = np.arange(len(self.hist)), int(7.5*adj*self.cb.res(len(self.hist)))
 		V_i, L = np.log(np.log(np.sqrt(self.hist+1.0)+1.0)+1.0), len(x)-dead
-		while self.hist[dead]==0:
+		while dead<len(self.hist) and self.hist[dead]==0:
 			dead += 1
 		
 		for M in np.linspace(0, 7.5*adj, 10):

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -94,7 +94,7 @@ class Spectrum(object):
 
 	def __init__(self, filename=None, **kwargs):
 		self.filename = filename
-		if 'cb' in kwargs:
+		if kwargs.get('cb') is not None:
 			if type(kwargs['cb'])==str:
 				self._cb = Calibration(kwargs['cb'])
 			else:
@@ -394,7 +394,9 @@ class Spectrum(object):
 
 	@cb.setter
 	def cb(self, _cb):
-		if type(_cb)==str:
+		if _cb is None:
+			self._cb = Calibration()
+		elif type(_cb)==str:
 			self._cb = Calibration(_cb)
 		else:
 			self._cb = copy.deepcopy(_cb)

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -1092,12 +1092,20 @@ class Spectrum(object):
 	def _multi_fit(self, p0):
 		chan = np.arange(len(self.hist))
 		try:
-			fit, unc = curve_fit(self._multiplet, chan[p0['l']:p0['h']], self.hist[p0['l']:p0['h']], p0=p0['p0'], bounds=p0['bounds'], sigma=np.sqrt(self.hist[p0['l']:p0['h']]+0.1))
+			# absolute_sigma: the sigmas are true Poisson standard deviations, so the
+			# covariance carries the full counting statistics. Scipy's default rescale
+			# by the reduced chi-square is biased below 1 for clean peaks in wide
+			# windows of near-empty channels, pushing unc_counts under the sqrt(N)
+			# counting floor; instead, inflate by chi2/dof only when it exceeds 1
+			# (scale-factor convention for model mismatch), never deflate.
+			fit, unc = curve_fit(self._multiplet, chan[p0['l']:p0['h']], self.hist[p0['l']:p0['h']], p0=p0['p0'], bounds=p0['bounds'], sigma=np.sqrt(self.hist[p0['l']:p0['h']]+0.1), absolute_sigma=True)
+			chi2 = self._chi2(fit, p0['l'], p0['h'])
+			if np.isfinite(chi2) and chi2>1.0:
+				unc = unc*chi2
 			p0['fit'] = fit
 			p0['unc'] = unc
 			N, unc_N = self._counts(fit, unc)
 			D, unc_D, A, unc_A = self._decays(N, unc_N, p0['df'])
-			chi2 = self._chi2(fit, p0['l'], p0['h'])
 
 			f = p0['df']
 			cols = ['filename','isotope','energy','counts','unc_counts',

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -838,14 +838,18 @@ class Spectrum(object):
 
 				# CHECK FOR IDENTICAL PEAKS
 				ix = self.cb.map_channel(g['energy']) # g is already sorted by energy
-				for n,x in enumerate(ix[:-1]):
-					if abs(x-ix[n+1])<=self.fit_config['ident_idx']:
-						if n in g.index:
-							print('WARNING: Isotope',i,'has un-resolvable gammas at',g.loc[n]['energy'],'and',g.loc[n+1]['energy'],'... Intensities will be combined.')
-							drop,replace = (n,n+1) if g.loc[n]['intensity']<g.loc[n+1]['intensity'] else (n+1,n)
-							g.loc[replace]['intensity'] += g.loc[drop]['intensity']
-							g.loc[replace]['unc_intensity'] = np.sqrt(g.loc[drop]['unc_intensity']**2 + g.loc[replace]['unc_intensity']**2)
-							g.drop(drop,inplace=True)
+				groups = [[0]] if len(ix) else []
+				for n in range(1, len(ix)):
+					if abs(ix[n]-ix[n-1])<=self.fit_config['ident_idx']:
+						groups[-1].append(n)
+					else:
+						groups.append([n])
+				for gp in [gp for gp in groups if len(gp)>1]:
+					print('WARNING: Isotope',i,'has un-resolvable gammas at',', '.join(map(str, g.loc[gp,'energy'])),'... Intensities will be combined.')
+					keep = g.loc[gp,'intensity'].idxmax()
+					g.loc[keep,'intensity'] = g.loc[gp,'intensity'].sum()
+					g.loc[keep,'unc_intensity'] = np.sqrt((g.loc[gp,'unc_intensity']**2).sum())
+					g.drop([p for p in gp if p!=keep], inplace=True)
 
 				if len(g):
 					itps.append(i)

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -858,7 +858,7 @@ class Spectrum(object):
 	def _chi2(self, fit, l ,h):
 		non_zero = np.where(self.hist[l:h]>0)
 		dof = float(len(non_zero[0])-len(fit)-1)
-		if dof==0:
+		if dof<=0:
 			return np.inf
 		resid = self.hist[l:h][non_zero]-self._multiplet(np.arange(l,h)[non_zero], *fit)
 		return np.sum(resid**2/self.hist[l:h][non_zero])/dof

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -918,7 +918,10 @@ class Spectrum(object):
 			corr = self._geom_corr*self._atten_corr(df['energy'])
 			
 		D = N/(df['intensity']*self.cb.eff(df['energy'])*corr*(self.live_time/self.real_time))
-		unc_D = D*np.sqrt((N/N**2)+(unc_N/N)**2+(self.cb.unc_eff(df['energy'])/self.cb.eff(df['energy']))**2+(df['unc_intensity']/df['intensity'])**2)
+		# unc_N is propagated from the weighted-least-squares covariance, which is the
+		# full sampling covariance under Poisson channel counts - it already contains
+		# the counting statistics of the peak area, so no separate 1/N term is added
+		unc_D = D*np.sqrt((unc_N/N)**2+(self.cb.unc_eff(df['energy'])/self.cb.eff(df['energy']))**2+(df['unc_intensity']/df['intensity'])**2)
 
 		A, unc_A = D/self.real_time, unc_D/self.real_time
 		return D, unc_D, A, unc_A

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -356,7 +356,7 @@ class Spectrum(object):
 			# loop over lines
 			for line in f:
 				# strip prefix and tokenize
-					line = line.strip("A004")
+					line = line.removeprefix('A004')
 					token = line.split()
 					
 					if entry == 1:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = u'2024, Jonathan Morrell'
 author = u'Jonathan Morrell'
 
 # The short X.Y version
-version = u'0.0.35'
+version = u'0.0.36'
 # The full version, including alpha/beta/rc tags
-release = u'0.0.35'
+release = u'0.0.36'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='curie',
-	  version='0.0.35',
+	  version='0.0.36',
 	  description='Curie is a python toolkit to aid in the analysis of experimental nuclear data.',
 	  long_description=long_description,
 	  long_description_content_type="text/markdown",


### PR DESCRIPTION
Result-changing release per the crashes-vs-numbers split: every changed number is called out in the changelog with magnitude and cause, and a before/after benchmark (152Eu spectrum end-to-end + affected reactions/chains) was run against v0.0.35.

**Changed results (all intended, old values were wrong):**
- Activity/decay uncertainties no longer double-count the Poisson term (derivation + 400-rep Monte Carlo: the weighted-LSQ covariance already carries counting statistics; the old model overestimated clean-peak uncertainties by sqrt(2)). Benchmark: -1.2% to -10.2% on the 152Eu lines; central values unchanged.
- Un-resolvable gamma lines actually merge now (chained-assignment bug, GH #8 follow-up): 152Eu 719.3 keV combined intensity +38%, inferred decays -27.5%, eu fit_R -0.8%.
- No off-grid cross-section extrapolation: 90Zr(n,2n)@30 MeV 903.7 mb -> 0; natTi(p,x)46Sc averaged past its 80 MeV grid ceiling -22% (lanthanum validation baseline re-recorded with provenance).
- Exact/near decay-constant ties use the exact confluent Bateman terms (154Hf->154Lu now gives the analytic in-growth); chains are unit-independent and extend to true stability (238U series now computable in every unit); branch-wise geometric-mean rescaling keeps the partial-fraction products inside float64 for any units (previously 1E302 in 1/Gy) with machine-precision unit invariance.

**Also fixed:** .Spe fractional times, IEC final-line loss, all-zero spectra, negative chi2, map_channel guards, formula-parser duplicate rows, chain-dedup key, NaN fit bounds, bare-element-symbol guidance, isomer mass convention, stable-isotope counts error, cb=None default.

Choreography: 17 curie-validation regression tests flipped red-to-green with markers removed in step; two new time-unit-invariance hardening tests on the deep 238U branches; public suite (72) green throughout; all validation cases green after the one documented re-record.

The authors acknowledge the assistance of Claude, an AI model provided by Anthropic, in the writing of this software.