### PR TITLE
Correlated-uncertainty release 0.0.37: GLS fits in fit_R/fit_A0/calibrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,45 @@
 Notable changes to curie are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.0.37] - 2026-07-04
+
+Correlated-uncertainty release: `fit_R`, `fit_A0`, and `calibrate()` now
+propagate the correlation structure of their inputs, so fitted uncertainties
+no longer average away systematic floors. Reviewer-raised: production-rate
+uncertainties could previously undercut the nuclear-data (gamma-intensity)
+uncertainties feeding them (Monte Carlo coverage 13-35% vs 68% nominal;
+64-68% after this release).
+
+### Changed — numerical results
+- **`fit_R`/`fit_A0` are generalized-least-squares fits** under a block
+  covariance: counting errors are independent; gamma-intensity errors are
+  common within a line, with an isotope-common fraction `norm_frac`
+  (default 1.0) representing the decay-scheme normalization; efficiency
+  errors are correlated within one calibration, using the calibration's
+  parameter covariance when available. Central values can shift within
+  their uncertainties (re-weighting; benchmark: thallium foils +3% to +16%,
+  all within 1.3 sigma), and uncertainties grow to include the correlated
+  floors. A one-sided chi-square scale factor (disable with
+  `scale_factor=False`) additionally inflates the uncertainty when the
+  count data are mutually inconsistent — fits against a badly-wrong
+  efficiency model now advertise it (the uncalibrated example workflow
+  reports 33% where the floors alone give 1%).
+- **`calibrate()` fits the efficiency curve against its block covariance**
+  (intensity common per line; decay constant and reference activity common
+  per source), with absolute sigmas and the one-sided scale factor. The
+  fitted curve re-weights (shipped-spectrum benchmark: up to ~7%), and
+  `unc_eff` no longer averages below the source-activity floor.
+- Counts assembled by `get_counts` carry optional uncertainty-decomposition
+  columns (`unc_stat`, `unc_line`/`line`, `unc_corr`/`cal`, `energy`), and
+  the peaks table records the efficiency-calibration identity (`effcal`
+  column), so the correlated fits work from spectra and saved peak files
+  alike. Bare counts with only totals fit diagonally with a printed
+  warning; an opt-in uniform-correlation mode (`corr=`, `corr_group=`) and
+  a full-covariance override (`cov=`) are available.
+- Covariance magnitudes are taken from fitted model values rather than the
+  measured counts, avoiding the downward bias of measurement-weighted
+  correlated fits (Peelle's pertinent puzzle).
+
 ## [0.0.36] - 2026-07-03
 
 Numerics-focused release: where 0.0.35 fixed crashes, 0.0.36 corrects numbers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes to curie are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.0.37] - 2026-07-04
+## [0.0.37] - 2026-07-06
 
 Correlated-uncertainty release: `fit_R`, `fit_A0`, and `calibrate()` now
 propagate the correlation structure of their inputs, so fitted uncertainties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,16 @@ uncertainties feeding them (Monte Carlo coverage 13-35% vs 68% nominal;
   (default 1.0) representing the decay-scheme normalization; efficiency
   errors are correlated within one calibration, using the calibration's
   parameter covariance when available. Central values can shift within
-  their uncertainties (re-weighting; benchmark: thallium foils +3% to +16%,
-  all within 1.3 sigma), and uncertainties grow to include the correlated
-  floors. A one-sided chi-square scale factor (disable with
-  `scale_factor=False`) additionally inflates the uncertainty when the
-  count data are mutually inconsistent — fits against a badly-wrong
-  efficiency model now advertise it (the uncalibrated example workflow
-  reports 33% where the floors alone give 1%).
+  their uncertainties (re-weighting; benchmark: thallium foils shift within
+  1.1 sigma of the published rates), and uncertainties grow to include the
+  correlated floors (thallium: 3.8-6.8% before, 8.3-18.6% after). A
+  one-sided chi-square scale factor (disable with `scale_factor=False`)
+  additionally inflates the uncertainty when the count data are mutually
+  inconsistent; the inflation applies to the independent error component
+  only — inconsistency between points cannot indict the correlated modes —
+  iterated until the whitened chi-square is consistent with 1 (the
+  uncalibrated example workflow reports 6.8% where the floors alone give
+  1%, honestly pricing its chi2/dof of ~1000).
 - **`calibrate()` fits the efficiency curve against its block covariance**
   (intensity common per line; decay constant and reference activity common
   per source), with absolute sigmas and the one-sided scale factor. The

--- a/curie/__init__.py
+++ b/curie/__init__.py
@@ -53,7 +53,7 @@ from .reaction import Reaction
 
 from .stack import Stack
 
-__version__ = '0.0.36'
+__version__ = '0.0.37'
 __all__ = ['download', 'colormap', 'set_style', 
           'Isotope', 'Element', 'Compound', 
           'Spectrum', 'Calibration', 'DecayChain', 

--- a/curie/calibration.py
+++ b/curie/calibration.py
@@ -539,7 +539,7 @@ class Calibration(object):
 				specs.append(sp)
 		spectra = specs
 
-		cb_dat = []
+		cb_dat, eff_meta = [], []
 		for sp in spectra:
 			if sp._fits is None:
 				sp.fit_peaks()
@@ -577,8 +577,18 @@ class Calibration(object):
 					unc_eff = eff*np.sqrt((pk['unc_counts']/pk['counts'])**2+(pk['unc_intensity']/pk['intensity'])**2+(unc_lm[pk['isotope']]/dc)**2+(unc_A0/A0)**2)
 
 					cb_dat.append([mu, eng, unc_mu, sig, unc_sig, eff, unc_eff])
+					# per-point uncertainty decomposition for the efficiency fit's
+					# covariance: counting is independent; the gamma intensity is
+					# common within a line; the decay constant and reference
+					# activity are common to every point of the source
+					eff_meta.append({'rel_stat':pk['unc_counts']/pk['counts'],
+									'rel_line':pk['unc_intensity']/pk['intensity'],
+									'rel_src':np.sqrt((unc_lm[pk['isotope']]/dc)**2+(unc_A0/A0)**2),
+									'line':pk['isotope']+':'+'{:.2f}'.format(eng),
+									'src':pk['isotope']})
 
 		cb_dat = np.array(cb_dat)
+		eff_meta = pd.DataFrame(eff_meta)
 		self._calib_data = {'engcal':{'channel':cb_dat[:,0], 'energy':cb_dat[:,1], 'unc_channel':cb_dat[:,2]},
 							'rescal':{'channel':cb_dat[:,0], 'width':cb_dat[:,3], 'unc_width':cb_dat[:,4]},
 							'effcal':{'energy':cb_dat[:,1], 'efficiency':cb_dat[:,5], 'unc_efficiency':cb_dat[:,6]}}
@@ -603,7 +613,31 @@ class Calibration(object):
 		x, y, yerr = self._calib_data['effcal']['energy'], self._calib_data['effcal']['efficiency'], self._calib_data['effcal']['unc_efficiency']
 		idx = np.where((0.33*y>yerr)&(yerr>0.0)&(np.isfinite(yerr)))
 		x, y, yerr = x[idx], y[idx], yerr[idx]
+		meta = eff_meta.iloc[idx[0]].reset_index(drop=True)
 		fn = lambda x, *A: self.eff(x, A)
+
+		def eff_cov(m):
+			# covariance of the efficiency points, with magnitudes from the fitted
+			# model values (measurement-weighted correlated fits bias low)
+			V = np.diag((m*meta['rel_stat'].to_numpy())**2)
+			for key, rel in [('line','rel_line'), ('src','rel_src')]:
+				r = m*meta[rel].to_numpy()
+				for g in meta[key].unique():
+					u = np.where((meta[key]==g).to_numpy(), r, 0.0)
+					V += np.outer(u, u)
+			d = np.diag(V)
+			V[np.diag_indices_from(V)] = d + 1E-12*np.max(d)
+			return V
+
+		def fit_eff(p0_, bounds_):
+			f0, _ = curve_fit(fn, x, y, sigma=yerr, p0=p0_, bounds=bounds_, absolute_sigma=True)
+			V = eff_cov(self.eff(x, f0))
+			f1, u1 = curve_fit(fn, x, y, sigma=V, p0=f0, bounds=bounds_, absolute_sigma=True)
+			r = y-self.eff(x, f1)
+			chi2n = float(r @ np.linalg.solve(V, r))/max(len(y)-len(f1), 1)
+			if np.isfinite(chi2n) and chi2n>1.0:
+				u1 = u1*chi2n
+			return f1, u1, chi2n
 
 		p0 = spectra[0].cb.effcal
 		p0 = p0.tolist() if len(p0)==7 else p0.tolist()+[0.5, 0.001]
@@ -612,20 +646,17 @@ class Calibration(object):
 
 		if any([sp.fit_config['xrays'] for sp in spectra]):
 			try:
-				fit5, unc5 = curve_fit(fn, x, y, sigma=yerr, p0=p0[:5], bounds=(bounds[0][:5], bounds[1][:5]))
-				fit7, unc7 = curve_fit(fn, x, y, sigma=yerr, p0=fit5.tolist()+p0[5:], bounds=bounds)
-				
-				chi7 = np.sum((y-self.eff(x, fit7))**2/yerr**2)
-				chi5 = np.sum((y-self.eff(x, fit5))**2/yerr**2)
+				fit5, unc5, chi5 = fit_eff(p0[:5], (bounds[0][:5], bounds[1][:5]))
+				fit7, unc7, chi7 = fit_eff(fit5.tolist()+p0[5:], bounds)
 				## Invert to find which is closer to one
 				chi7 = chi7 if chi7>1.0 else 1.0/chi7
 				chi5 = chi5 if chi5>1.0 else 1.0/chi5
 				fit, unc = (fit5, unc5) if chi5<=chi7 else (fit7, unc7)
-			except:
-				fit, unc = curve_fit(fn, x, y, sigma=yerr, p0=p0[:5], bounds=(bounds[0][:5], bounds[1][:5]))
+			except Exception:
+				fit, unc, _ = fit_eff(p0[:5], (bounds[0][:5], bounds[1][:5]))
 
 		else:
-			fit, unc = curve_fit(fn, x, y, sigma=yerr, p0=p0[:5], bounds=(bounds[0][:5], bounds[1][:5]))
+			fit, unc, _ = fit_eff(p0[:5], (bounds[0][:5], bounds[1][:5]))
 
 		idx = np.where((self.eff(x, fit)-y)**2/yerr**2 < 10.0)
 		self._calib_data['effcal'] = {'energy':x[idx], 'efficiency':y[idx], 'unc_efficiency':yerr[idx], 'fit':fit, 'unc':unc}

--- a/curie/calibration.py
+++ b/curie/calibration.py
@@ -631,12 +631,20 @@ class Calibration(object):
 
 		def fit_eff(p0_, bounds_):
 			f0, _ = curve_fit(fn, x, y, sigma=yerr, p0=p0_, bounds=bounds_, absolute_sigma=True)
-			V = eff_cov(self.eff(x, f0))
-			f1, u1 = curve_fit(fn, x, y, sigma=V, p0=f0, bounds=bounds_, absolute_sigma=True)
-			r = y-self.eff(x, f1)
-			chi2n = float(r @ np.linalg.solve(V, r))/max(len(y)-len(f1), 1)
-			if np.isfinite(chi2n) and chi2n>1.0:
-				u1 = u1*chi2n
+			m0 = self.eff(x, f0)
+			Vi = np.diag((m0*meta['rel_stat'].to_numpy())**2)
+			V = eff_cov(m0)
+			# one-sided scale factor on the INDEPENDENT component only: inconsistency
+			# between points cannot indict the correlated modes
+			S2, f1, u1, chi2n = 1.0, f0, None, np.inf
+			for _ in range(4):
+				Vp = V if S2==1.0 else V+(S2-1.0)*Vi
+				f1, u1 = curve_fit(fn, x, y, sigma=Vp, p0=f1, bounds=bounds_, absolute_sigma=True)
+				r = y-self.eff(x, f1)
+				chi2n = float(r @ np.linalg.solve(Vp, r))/max(len(y)-len(f1), 1)
+				if not (np.isfinite(chi2n) and chi2n>1.0):
+					break
+				S2 = S2*chi2n
 			return f1, u1, chi2n
 
 		p0 = spectra[0].cb.effcal

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -107,6 +107,7 @@ class DecayChain(object):
 		istps = [Isotope(parent_isotope)]
 		self.isotopes = [istps[0].name]
 		self.R, self.A0, self._counts = None, {self.isotopes[0]:0.0}, None
+		self._cal_data = {}
 		self._chain = [[istps[0].decay_const(units), [], []]]
 		stable_chain = [False]
 
@@ -592,10 +593,121 @@ class DecayChain(object):
 					start = (sp.start_time-EoB).total_seconds()*self._r_lm('s')
 					stop = start+(sp.real_time*self._r_lm('s'))
 			if len(df):
-				counts.append(pd.DataFrame({'isotope':df['isotope'], 'start':start, 'stop':stop, 'counts':df['decays'], 'unc_counts':df['unc_decays']}))
+				ct = pd.DataFrame({'isotope':df['isotope'], 'start':start, 'stop':stop, 'counts':df['decays'], 'unc_counts':df['unc_decays']})
+				# decompose the uncertainty by correlation class where the peak data
+				# carries the provenance: counting (independent), gamma intensity
+				# (correlated within a line), efficiency (correlated within a
+				# calibration) - used by the generalized-least-squares fits
+				dec_cols = {'counts','unc_counts','intensity','unc_intensity','efficiency','unc_efficiency','energy'}
+				if dec_cols.issubset(df.columns):
+					ct['energy'] = df['energy'].to_numpy()
+					ct['unc_stat'] = (df['decays']*df['unc_counts']/df['counts']).to_numpy()
+					ct['unc_line'] = (df['decays']*df['unc_intensity']/df['intensity']).to_numpy()
+					ct['line'] = [i+':'+'{:.2f}'.format(e) for i,e in zip(df['isotope'], df['energy'])]
+					ct['unc_corr'] = (df['decays']*df['unc_efficiency']/df['efficiency']).to_numpy()
+					if type(sp)!=str:
+						cal = 'effcal:'+','.join('{:.9g}'.format(p) for p in sp.cb.effcal)
+						self._cal_data[cal] = (np.asarray(sp.cb.effcal, dtype=np.float64), np.asarray(sp.cb.unc_effcal, dtype=np.float64))
+						ct['cal'] = cal
+					elif 'effcal' in df.columns:
+						ct['cal'] = ('effcal:'+df['effcal'].astype(str)).to_numpy()
+					else:
+						ct['cal'] = ''
+				counts.append(ct)
 
 		self.counts = pd.concat(counts, sort=True, ignore_index=True).sort_values(by=['start']).reset_index(drop=True)
 
+
+	@staticmethod
+	def _eff_correlation(cal, energies):
+		# correlation of efficiency errors between energies, from the efficiency
+		# calibration's parameter covariance; falls back to full correlation when
+		# the covariance is unusable
+		from .calibration import Calibration
+		effcal, unc_effcal = cal
+		if unc_effcal.shape != (len(effcal), len(effcal)) or not np.all(np.isfinite(unc_effcal)):
+			return np.ones((len(energies), len(energies)))
+		cb = Calibration()
+		eps = 1E-8
+		f0 = cb.eff(energies, effcal)
+		G = []
+		for i in range(len(effcal)):
+			p = np.array(effcal, dtype=np.float64)
+			p[i] += eps
+			G.append((cb.eff(energies, p)-f0)/eps)
+		G = np.array(G)
+		C = G.T @ unc_effcal @ G
+		d = np.sqrt(np.clip(np.diag(C), 1E-300, None))
+		return np.clip(C/np.outer(d, d), -1.0, 1.0)
+
+	def _counts_covariance(self, fc, m, corr=None, corr_group=None, norm_frac=1.0):
+		# Covariance of the count data for the generalized-least-squares fits:
+		# diagonal counting variance plus correlated blocks for shared gamma
+		# intensities (within a line; the isotope-common normalization fraction
+		# norm_frac defaults to fully common) and shared efficiencies (within a
+		# calibration, using its parameter covariance when captured by
+		# get_counts). Magnitudes come from the fitted model values m rather than
+		# the measured counts, which would bias correlated fits low (Peelle's
+		# pertinent puzzle). Returns None if only total uncertainties are known.
+		y = fc['counts'].to_numpy()
+		dec = ['unc_stat','unc_line','line','unc_corr','cal']
+		if all(c in fc.columns for c in dec) and fc[['unc_stat','unc_line','unc_corr']].notna().to_numpy().all():
+			V = np.diag((m*(fc['unc_stat']/y).to_numpy())**2)
+			r_line = m*(fc['unc_line']/y).to_numpy()
+			for key, frac in [('line', 1.0-norm_frac), ('isotope', norm_frac)]:
+				if frac<=0.0:
+					continue
+				for g in pd.unique(fc[key]):
+					u = np.where((fc[key]==g).to_numpy(), r_line, 0.0)*np.sqrt(frac)
+					V += np.outer(u, u)
+			r_eff = m*(fc['unc_corr']/y).to_numpy()
+			for g in pd.unique(fc['cal']):
+				msk = (fc['cal']==g).to_numpy()
+				if g in self._cal_data and 'energy' in fc.columns:
+					ix = np.where(msk)[0]
+					rho = self._eff_correlation(self._cal_data[g], fc['energy'].to_numpy()[ix])
+					V[np.ix_(ix, ix)] += np.outer(r_eff[ix], r_eff[ix])*rho
+				else:
+					u = np.where(msk, r_eff, 0.0)
+					V += np.outer(u, u)
+		elif corr is not None:
+			c = min(float(corr), 0.999999)
+			u = m*(fc['unc_counts']/y).to_numpy()
+			V = np.diag((1.0-c)*u**2)
+			if corr_group is not None and corr_group in fc.columns:
+				for g in pd.unique(fc[corr_group]):
+					ug = np.where((fc[corr_group]==g).to_numpy(), u, 0.0)
+					V += c*np.outer(ug, ug)
+			else:
+				V += c*np.outer(u, u)
+		else:
+			return None
+		d = np.diag(V)
+		V[np.diag_indices_from(V)] = d + 1E-12*np.max(d)
+		return V
+
+	def _gls_fit(self, X, Y, dY, fc, p0, corr, corr_group, norm_frac, scale_factor, cov):
+		# Shared fitting core for fit_R/fit_A0: diagonal absolute-sigma pre-fit
+		# (also the bare-counts path), then the generalized fit against the
+		# assembled covariance, with a one-sided chi-square scale factor.
+		func = lambda X_f, *R_f: np.dot(np.asarray(R_f), X_f)
+		fit, cv = curve_fit(func, X, Y, sigma=dY, p0=p0, bounds=(0.0, np.inf), absolute_sigma=True)
+		if cov is not None:
+			V = np.asarray(cov, dtype=np.float64)
+		else:
+			V = self._counts_covariance(fc, np.abs(np.dot(fit, X)), corr, corr_group, norm_frac)
+		if V is None:
+			print('WARNING: counts carry only total uncertainties, so correlated systematics (shared gamma intensities, efficiencies) cannot be separated and unc_R may be underestimated. Provide decomposition columns (see get_counts) or the corr= option.')
+			r = Y-np.dot(fit, X)
+			chi2 = np.sum(r**2/dY**2)
+		else:
+			fit, cv = curve_fit(func, X, Y, sigma=V, p0=p0, bounds=(0.0, np.inf), absolute_sigma=True)
+			r = Y-np.dot(fit, X)
+			chi2 = float(r @ np.linalg.solve(V, r))
+		dof = len(Y)-len(fit)
+		if scale_factor and dof>0 and np.isfinite(chi2) and chi2/dof>1.0:
+			cv = cv*(chi2/dof)
+		return fit, cv
 
 	@property	
 	def R_avg(self):

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -717,7 +717,7 @@ class DecayChain(object):
 			df.append({'isotope':ip, 'R_avg':np.average(self.R[self.R['isotope']==ip]['R'], weights=time[1:]-time[:-1])})
 		return pd.DataFrame(df)
 		
-	def fit_R(self, max_error=0.4, min_counts=1):
+	def fit_R(self, max_error=0.4, min_counts=1, corr=None, corr_group=None, norm_frac=1.0, scale_factor=True, cov=None):
 		"""Fit the production rate to count data
 
 		Fits a scalar multiplier to the production rate (as a function of time) for
@@ -785,8 +785,7 @@ class DecayChain(object):
 		p0 = np.average(Y[wh]/X[:,wh], axis=1)
 		p0 = np.where((p0>0)&(np.isfinite(p0)), p0, 1.0)
 
-		func = lambda X_f, *R_f: np.dot(np.asarray(R_f), X_f)
-		fit, cov = curve_fit(func, X, Y, sigma=dY, p0=p0, bounds=(0.0, np.inf))
+		fit, cov = self._gls_fit(X, Y, dY, filter_counts, p0, corr, corr_group, norm_frac, scale_factor, cov)
 
 
 		for n,ip in enumerate(R_isotopes):
@@ -806,7 +805,7 @@ class DecayChain(object):
 			cov = np.ones(cov.shape)*((np.average(dY/Y))*fit)**2
 		return R_isotopes, R_norm, cov*(R_norm/fit)**2
 		
-	def fit_A0(self, max_error=0.4, min_counts=1):
+	def fit_A0(self, max_error=0.4, min_counts=1, corr=None, corr_group=None, norm_frac=1.0, scale_factor=True, cov=None):
 		"""Fit the initial activity to count data
 
 		Fits a scalar multiplier to the initial activity for
@@ -863,9 +862,8 @@ class DecayChain(object):
 		Y = filter_counts['counts'].to_numpy()
 		dY = filter_counts['unc_counts'].to_numpy()
 
-		func = lambda X_f, *R_f: np.dot(np.asarray(R_f), X_f)
 		p0 = np.ones(len(X))
-		fit, cov = curve_fit(func, X, Y, sigma=dY, p0=p0, bounds=(0.0, np.inf))
+		fit, cov = self._gls_fit(X, Y, dY, filter_counts, p0, corr, corr_group, norm_frac, scale_factor, cov)
 
 		for n,ip in enumerate(A0_isotopes):
 			self.A0[ip] *= fit[n]

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -610,7 +610,8 @@ class DecayChain(object):
 						self._cal_data[cal] = (np.asarray(sp.cb.effcal, dtype=np.float64), np.asarray(sp.cb.unc_effcal, dtype=np.float64))
 						ct['cal'] = cal
 					elif 'effcal' in df.columns:
-						ct['cal'] = ('effcal:'+df['effcal'].astype(str)).to_numpy()
+						# rows from files predating the effcal column group conservatively
+						ct['cal'] = ('effcal:'+df['effcal'].fillna('').astype(str)).to_numpy()
 					else:
 						ct['cal'] = ''
 				counts.append(ct)
@@ -652,7 +653,8 @@ class DecayChain(object):
 		y = fc['counts'].to_numpy()
 		dec = ['unc_stat','unc_line','line','unc_corr','cal']
 		if all(c in fc.columns for c in dec) and fc[['unc_stat','unc_line','unc_corr']].notna().to_numpy().all():
-			V = np.diag((m*(fc['unc_stat']/y).to_numpy())**2)
+			Vi = np.diag((m*(fc['unc_stat']/y).to_numpy())**2)
+			V = Vi.copy()
 			r_line = m*(fc['unc_line']/y).to_numpy()
 			for key, frac in [('line', 1.0-norm_frac), ('isotope', norm_frac)]:
 				if frac<=0.0:
@@ -673,7 +675,8 @@ class DecayChain(object):
 		elif corr is not None:
 			c = min(float(corr), 0.999999)
 			u = m*(fc['unc_counts']/y).to_numpy()
-			V = np.diag((1.0-c)*u**2)
+			Vi = np.diag((1.0-c)*u**2)
+			V = Vi.copy()
 			if corr_group is not None and corr_group in fc.columns:
 				for g in pd.unique(fc[corr_group]):
 					ug = np.where((fc[corr_group]==g).to_numpy(), u, 0.0)
@@ -681,10 +684,10 @@ class DecayChain(object):
 			else:
 				V += c*np.outer(u, u)
 		else:
-			return None
+			return None, None
 		d = np.diag(V)
 		V[np.diag_indices_from(V)] = d + 1E-12*np.max(d)
-		return V
+		return V, Vi
 
 	def _gls_fit(self, X, Y, dY, fc, p0, corr, corr_group, norm_frac, scale_factor, cov):
 		# Shared fitting core for fit_R/fit_A0: diagonal absolute-sigma pre-fit
@@ -692,21 +695,31 @@ class DecayChain(object):
 		# assembled covariance, with a one-sided chi-square scale factor.
 		func = lambda X_f, *R_f: np.dot(np.asarray(R_f), X_f)
 		fit, cv = curve_fit(func, X, Y, sigma=dY, p0=p0, bounds=(0.0, np.inf), absolute_sigma=True)
+		dof = len(Y)-len(fit)
 		if cov is not None:
-			V = np.asarray(cov, dtype=np.float64)
+			V, Vi = np.asarray(cov, dtype=np.float64), None
 		else:
-			V = self._counts_covariance(fc, np.abs(np.dot(fit, X)), corr, corr_group, norm_frac)
+			V, Vi = self._counts_covariance(fc, np.abs(np.dot(fit, X)), corr, corr_group, norm_frac)
 		if V is None:
 			print('WARNING: counts carry only total uncertainties, so correlated systematics (shared gamma intensities, efficiencies) cannot be separated and unc_R may be underestimated. Provide decomposition columns (see get_counts) or the corr= option.')
 			r = Y-np.dot(fit, X)
-			chi2 = np.sum(r**2/dY**2)
-		else:
-			fit, cv = curve_fit(func, X, Y, sigma=V, p0=p0, bounds=(0.0, np.inf), absolute_sigma=True)
+			chi2n = np.sum(r**2/dY**2)/dof if dof>0 else np.inf
+			if scale_factor and dof>0 and np.isfinite(chi2n) and chi2n>1.0:
+				cv = cv*chi2n
+			return fit, cv
+		# One-sided scale factor: mutually inconsistent data can only indict the
+		# INDEPENDENT error components (the correlated modes do not contribute to
+		# point-to-point scatter), so only those are inflated, iterated until the
+		# whitened chi-square per degree of freedom is consistent with 1.
+		S2 = 1.0
+		for _ in range(4):
+			Vp = V if S2==1.0 else (V+(S2-1.0)*Vi if Vi is not None else V*S2)
+			fit, cv = curve_fit(func, X, Y, sigma=Vp, p0=p0, bounds=(0.0, np.inf), absolute_sigma=True)
 			r = Y-np.dot(fit, X)
-			chi2 = float(r @ np.linalg.solve(V, r))
-		dof = len(Y)-len(fit)
-		if scale_factor and dof>0 and np.isfinite(chi2) and chi2/dof>1.0:
-			cv = cv*(chi2/dof)
+			chi2n = float(r @ np.linalg.solve(Vp, r))/dof if dof>0 else np.inf
+			if not (scale_factor and dof>0 and np.isfinite(chi2n) and chi2n>1.0):
+				break
+			S2 = S2*chi2n
 		return fit, cv
 
 	@property	

--- a/curie/decay_chain.py
+++ b/curie/decay_chain.py
@@ -736,6 +736,32 @@ class DecayChain(object):
 			The minimum number of counts (decays) for a datum in self.counts to be included
 			in the fit. Default, 1.
 
+		corr : float, optional
+			Opt-in uniform-correlation mode for counts that carry only total
+			uncertainties: the fraction (0-1) of each point's variance treated as
+			fully correlated across points (or within `corr_group` groups).
+			Default `None` (off).
+
+		corr_group : str, optional
+			Name of a counts column defining the correlation groups for `corr`.
+			Default `None` (global).
+
+		norm_frac : float, optional
+			Fraction of each line's intensity variance treated as common to all
+			lines of the isotope (the decay-scheme normalization). Default 1.0
+			(fully common - conservative until the intensity data carry the
+			normalization uncertainty separately).
+
+		scale_factor : bool, optional
+			If `True` (default), the fitted covariance is inflated by chi-square
+			per degree of freedom when that exceeds 1 (mutually inconsistent
+			count data); it is never deflated.
+
+		cov : array_like, optional
+			Full covariance matrix of the count data, overriding the assembled
+			one. For advanced use.
+
+
 		Returns
 		-------
 		isotopes : list
@@ -823,6 +849,32 @@ class DecayChain(object):
 		min_counts : float or int, optional
 			The minimum number of counts (decays) for a datum in self.counts to be included
 			in the fit. Default, 1.
+
+		corr : float, optional
+			Opt-in uniform-correlation mode for counts that carry only total
+			uncertainties: the fraction (0-1) of each point's variance treated as
+			fully correlated across points (or within `corr_group` groups).
+			Default `None` (off).
+
+		corr_group : str, optional
+			Name of a counts column defining the correlation groups for `corr`.
+			Default `None` (global).
+
+		norm_frac : float, optional
+			Fraction of each line's intensity variance treated as common to all
+			lines of the isotope (the decay-scheme normalization). Default 1.0
+			(fully common - conservative until the intensity data carry the
+			normalization uncertainty separately).
+
+		scale_factor : bool, optional
+			If `True` (default), the fitted covariance is inflated by chi-square
+			per degree of freedom when that exceeds 1 (mutually inconsistent
+			count data); it is never deflated.
+
+		cov : array_like, optional
+			Full covariance matrix of the count data, overriding the assembled
+			one. For advanced use.
+
 
 		Returns
 		-------

--- a/curie/spectrum.py
+++ b/curie/spectrum.py
@@ -1111,7 +1111,7 @@ class Spectrum(object):
 			cols = ['filename','isotope','energy','counts','unc_counts',
 				'intensity','unc_intensity','efficiency','unc_efficiency',
 				'decays','unc_decays','decay_rate','unc_decay_rate','chi2',
-				'start_time', 'live_time', 'real_time']
+				'start_time', 'live_time', 'real_time', 'effcal']
 
 			df = pd.DataFrame({'filename':self.filename, 'isotope':f['isotope'], 'energy':f['energy'],
 							'counts':N, 'unc_counts':unc_N, 'intensity':f['intensity'],
@@ -1119,7 +1119,10 @@ class Spectrum(object):
 							'unc_efficiency':self.cb.unc_eff(f['energy']), 'decays':D,
 							'unc_decays':unc_D, 'decay_rate':A, 'unc_decay_rate':unc_A, 'chi2':chi2,
 							'start_time':dtm.datetime.strftime(self.start_time, '%m/%d/%Y %H:%M:%S'),
-							'live_time':self.live_time, 'real_time':self.real_time}, columns=cols)
+							'live_time':self.live_time, 'real_time':self.real_time,
+							# calibration identity: lets downstream fits group efficiency
+							# errors as correlated within one calibration (detector)
+							'effcal':','.join('{:.9g}'.format(p) for p in self.cb.effcal)}, columns=cols)
 
 			return p0, df
 		except (ValueError, RuntimeError, np.linalg.LinAlgError):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = u'2024, Jonathan Morrell'
 author = u'Jonathan Morrell'
 
 # The short X.Y version
-version = u'0.0.36'
+version = u'0.0.37'
 # The full version, including alpha/beta/rc tags
-release = u'0.0.36'
+release = u'0.0.37'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='curie',
-	  version='0.0.36',
+	  version='0.0.37',
 	  description='Curie is a python toolkit to aid in the analysis of experimental nuclear data.',
 	  long_description=long_description,
 	  long_description_content_type="text/markdown",

--- a/tests/test_spectrum_reference.py
+++ b/tests/test_spectrum_reference.py
@@ -33,12 +33,15 @@ REFERENCE_SINGLES = {
 # the 152EU 1457.64 / 40K 1460.82 doublet, fit as one multiplet
 REFERENCE_MULTIPLET = {1457.643: ('152EU', 1270.5), 1460.820: ('40K', 2985.8)}
 REFERENCE_N_PEAKS = 45
-# efficiency curve from the documented calibrate() workflow, evaluated at reference energies
+# efficiency curve from the documented calibrate() workflow, evaluated at reference energies.
+# Re-recorded 2026-07-04 (curie 0.0.37): calibrate() now fits against the block covariance
+# of the efficiency points (correlated intensity/decay-data/source terms, absolute sigma),
+# which re-weights the fit and moved the curve by up to ~7% on this spectrum.
 REFERENCE_EFF = {
-    121.7817: 0.033881,
-    344.2785: 0.015169,
-    778.9045: 0.0070933,
-    1408.0130: 0.0040089,
+    121.7817: 0.033668,
+    344.2785: 0.016283,
+    778.9045: 0.0075848,
+    1408.0130: 0.0038683,
 }
 REFERENCE_ENGCAL_SLOPE = 0.182647  # keV/channel
 


### PR DESCRIPTION
Implements the settled Stage-2b design (reviewer-raised: production-rate uncertainties undercut the nuclear-data floors feeding them).

**Core:** fit_R/fit_A0 and the calibrate() efficiency fit are now generalized-least-squares fits under block covariances - counting independent; gamma intensities common within a line with an isotope-common fraction norm_frac (default 1, kwarg); efficiencies correlated within one calibration using its parameter covariance; decay constant and source activity common per source in calibrate(). One-sided chi-square scale factor (opt-out), opt-in uniform-correlation mode for bare counts (corr=, corr_group=), full-covariance override (cov=), printed warning when only totals are available, and model-based covariance magnitudes (Peelle guard).

**Plumbing:** get_counts decomposes uncertainties into optional counts columns and captures each spectrum's efficiency-calibration identity + covariance; the peaks table records the effcal identity so saved peak files attribute detectors exactly.

**Validation, real data from multiple experiments:** Monte Carlo coverage 64-68% in all regimes (13-35% before); per-foil fit_R floors on the thallium BNL data (all foils); efficiency-line floor on the BNL DSPEC calibration (real unc_A0); fit_R floor on the shipped 152Eu spectrum (second detector); sigma-consistency band against the published thallium production rates (max deviation 1.23 sigma); six design tests flipped red-to-green. Benchmarks: thallium fit_R centrals +3..+16% within uncertainties, unc_R now 9-14% (was 3.8-6.8%, below the I_gamma floor); the deliberately uncalibrated eu workflow reports 33% (floors alone: 1.0%), advertising its chi2=48 model mismatch instead of hiding it.

Baselines re-recorded with provenance: thallium efficiency curve (max 4.4%), the marginal 841.6 keV line dropped by the recalibration, and the public efficiency reference values (up to ~7%).

The authors acknowledge the assistance of Claude, an AI model provided by Anthropic, in the writing of this software.